### PR TITLE
fix: scope model fallback by auth tier and validate sk- API key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ curl http://127.0.0.1:8000/v1/models
 - 使用 `Bearer <api-key>`：默认走 Zen；如果请求的是仅存在于 Go 目录中的模型，会自动切到 Go。
 - 使用 `Bearer zen:<api-key>`：强制走 Zen，适合你明确要用 Zen 按量计费目录时。
 - 使用 `Bearer go:<api-key>`：优先走 Go 订阅目录；共享模型也会按 Go 路径请求。
+- 无效或占位 key（如 `no-key-required`）会自动回退到 public 模式。
 
 Chat Completions 示例：
 

--- a/main.go
+++ b/main.go
@@ -1583,6 +1583,10 @@ func isFreeModel(modelID string) bool {
 }
 
 func buildOCRequest(modelID string, bodyMap map[string]any, auth UpstreamAuth) (*http.Request, error) {
+	return buildOCRequestWithEndpoint(modelID, bodyMap, auth, auth.shouldUseGoEndpoint(modelID))
+}
+
+func buildOCRequestWithEndpoint(modelID string, bodyMap map[string]any, auth UpstreamAuth, useGoEndpoint bool) (*http.Request, error) {
 	bodyMap["model"] = modelID
 	delete(bodyMap, "reasoning_effort")
 	tryBody, err := json.Marshal(bodyMap)
@@ -1590,7 +1594,7 @@ func buildOCRequest(modelID string, bodyMap map[string]any, auth UpstreamAuth) (
 		return nil, err
 	}
 	var upstreamURL string
-	if auth.shouldUseGoEndpoint(modelID) {
+	if useGoEndpoint {
 		upstreamURL = "https://opencode.ai/zen/go/v1/chat/completions"
 	} else {
 		upstreamURL = "https://opencode.ai/zen/v1/chat/completions"
@@ -1642,11 +1646,11 @@ func callOpenCodeAPI(upstreamBody []byte, modelID string, auth UpstreamAuth) ([]
 		modelsToTry = []string{modelID}
 	}
 
-	// 循环外解析一次
 	var bodyMap map[string]any
 	if err := json.Unmarshal(upstreamBody, &bodyMap); err != nil {
 		return nil, 500, nil, fmt.Errorf("invalid request body")
 	}
+	useGoEndpoint := auth.shouldUseGoEndpoint(modelID)
 
 	var lastErr error
 	var retryCount int
@@ -1655,7 +1659,7 @@ func callOpenCodeAPI(upstreamBody []byte, modelID string, auth UpstreamAuth) ([]
 	var lastStatus int
 	var lastHeader http.Header
 	for i, tryModel := range modelsToTry {
-		up, err := buildOCRequest(tryModel, bodyMap, auth)
+		up, err := buildOCRequestWithEndpoint(tryModel, bodyMap, auth, useGoEndpoint)
 		if err != nil {
 			lastErr = err
 			continue
@@ -1721,6 +1725,7 @@ func callOpenCodeAPIStream(upstreamBody []byte, modelID string, auth UpstreamAut
 	if err := json.Unmarshal(upstreamBody, &bodyMap); err != nil {
 		return nil, 500, nil, fmt.Errorf("invalid request body")
 	}
+	useGoEndpoint := auth.shouldUseGoEndpoint(modelID)
 
 	var lastBody []byte
 	var lastStatus int
@@ -1728,7 +1733,7 @@ func callOpenCodeAPIStream(upstreamBody []byte, modelID string, auth UpstreamAut
 	var retryCount int
 	var retry401Count int
 	for i, tryModel := range modelsToTry {
-		up, err := buildOCRequest(tryModel, bodyMap, auth)
+		up, err := buildOCRequestWithEndpoint(tryModel, bodyMap, auth, useGoEndpoint)
 		if err != nil {
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -433,6 +433,38 @@ func getModelIDs() []string {
 	return ids
 }
 
+func getGoModelIDs() []string {
+	modelMu.RLock()
+	defer modelMu.RUnlock()
+	ids := make([]string, len(goModelsCache))
+	for i, m := range goModelsCache {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+func filterFreeModels(ids []string) []string {
+	free := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if isFreeModel(id) {
+			free = append(free, id)
+		}
+	}
+	return free
+}
+
+// getCandidateModels 返回与当前认证权限一致的回退候选模型列表。
+// public 模式只回退到免费模型；带 key 的模式只回退到与目标模型走相同端点的模型，避免跨目录 401。
+func getCandidateModels(auth UpstreamAuth, modelID string) []string {
+	if auth.Mode == AuthRoutePublic {
+		return filterFreeModels(getModelIDs())
+	}
+	if auth.shouldUseGoEndpoint(modelID) {
+		return getGoModelIDs()
+	}
+	return getModelIDs()
+}
+
 // startModelRefresh 定时刷新模型列表（每 10 分钟）
 func startModelRefresh() {
 	go func() {
@@ -1589,9 +1621,9 @@ const (
 
 func callOpenCodeAPI(upstreamBody []byte, modelID string, auth UpstreamAuth) ([]byte, int, http.Header, error) {
 	initOCSession()
-	modelIDs := getModelIDs()
+	candidates := getCandidateModels(auth, modelID)
 	modelsToTry := []string{modelID}
-	for _, m := range modelIDs {
+	for _, m := range candidates {
 		if m != modelID {
 			modelsToTry = append(modelsToTry, m)
 		}
@@ -1664,9 +1696,9 @@ func callOpenCodeAPI(upstreamBody []byte, modelID string, auth UpstreamAuth) ([]
 
 func callOpenCodeAPIStream(upstreamBody []byte, modelID string, auth UpstreamAuth) (io.ReadCloser, int, http.Header, error) {
 	initOCSession()
-	modelIDs := getModelIDs()
+	candidates := getCandidateModels(auth, modelID)
 	modelsToTry := []string{modelID}
-	for _, m := range modelIDs {
+	for _, m := range candidates {
 		if m != modelID {
 			modelsToTry = append(modelsToTry, m)
 		}

--- a/main.go
+++ b/main.go
@@ -1525,17 +1525,27 @@ func extractUpstreamAuth(r *http.Request) UpstreamAuth {
 	if !strings.HasPrefix(auth, "Bearer ") {
 		return UpstreamAuth{Mode: AuthRoutePublic}
 	}
-	token := strings.TrimPrefix(auth, "Bearer ")
-	if token == "public" {
+	token := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
+	if token == "" || token == "public" {
 		return UpstreamAuth{Mode: AuthRoutePublic}
 	}
-	if strings.HasPrefix(token, "go:") {
-		return UpstreamAuth{Token: strings.TrimPrefix(token, "go:"), Mode: AuthRouteGo}
+	// go:/zen: 前缀路由：去掉前缀后剩余部分仍需是有效 key（sk- 开头）
+	if rest, ok := strings.CutPrefix(token, "go:"); ok && isValidOpenCodeKey(rest) {
+		return UpstreamAuth{Token: rest, Mode: AuthRouteGo}
 	}
-	if strings.HasPrefix(token, "zen:") {
-		return UpstreamAuth{Token: strings.TrimPrefix(token, "zen:"), Mode: AuthRouteZen}
+	if rest, ok := strings.CutPrefix(token, "zen:"); ok && isValidOpenCodeKey(rest) {
+		return UpstreamAuth{Token: rest, Mode: AuthRouteZen}
 	}
-	return UpstreamAuth{Token: token, Mode: AuthRouteAuto}
+	// 只有 sk- 开头的才是有效 key，其余（no-key-required 等占位符）一律走 public
+	if isValidOpenCodeKey(token) {
+		return UpstreamAuth{Token: token, Mode: AuthRouteAuto}
+	}
+	return UpstreamAuth{Mode: AuthRoutePublic}
+}
+
+// 只认 sk- 开头的 key，避免客户端占位 key（如 no-key-required）被透传给上游导致 401
+func isValidOpenCodeKey(token string) bool {
+	return strings.HasPrefix(token, "sk-") && len(token) > 15
 }
 
 func (auth UpstreamAuth) tier() TierType {

--- a/main_test.go
+++ b/main_test.go
@@ -369,12 +369,12 @@ func TestListModelsHandlerSeparatesPublicZenAndGoCatalogs(t *testing.T) {
 		},
 		{
 			name:       "bare zen key sees zen catalog only",
-			authHeader: "Bearer sk-auto",
+			authHeader: "Bearer sk-auto0123456789abcdef",
 			wantIDs:    []string{"deepseek-v4-flash-free", "glm-5.2", "gpt-5.5"},
 		},
 		{
 			name:       "go prefix sees free and go catalog",
-			authHeader: "Bearer go:sk-go",
+			authHeader: "Bearer go:sk-go0123456789abcdef",
 			wantIDs:    []string{"deepseek-v4-flash-free", "glm-5.2", "kimi-k2.7-code"},
 		},
 	}
@@ -404,6 +404,42 @@ func TestListModelsHandlerSeparatesPublicZenAndGoCatalogs(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotIDs, tt.wantIDs) {
 				t.Fatalf("listModelsHandler() ids = %#v, want %#v", gotIDs, tt.wantIDs)
+			}
+		})
+	}
+}
+
+func TestExtractUpstreamAuthKeyValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		wantMode   AuthRouteMode
+		wantToken  string
+	}{
+		{"no header", "", AuthRoutePublic, ""},
+		{"bearer empty", "Bearer ", AuthRoutePublic, ""},
+		{"bearer public", "Bearer public", AuthRoutePublic, ""},
+		{"bearer no-key-required placeholder", "Bearer no-key-required", AuthRoutePublic, ""},
+		{"bearer random non-key", "Bearer abc123xyz", AuthRoutePublic, ""},
+		{"valid sk key", "Bearer sk-validkey0123456789abcdef", AuthRouteAuto, "sk-validkey0123456789abcdef"},
+		{"go prefix with sk key", "Bearer go:sk-gokey0123456789abcdef", AuthRouteGo, "sk-gokey0123456789abcdef"},
+		{"zen prefix with sk key", "Bearer zen:sk-zenkey0123456789abcdef", AuthRouteZen, "sk-zenkey0123456789abcdef"},
+		{"go prefix with placeholder falls to public", "Bearer go:no-key-required", AuthRoutePublic, ""},
+		{"bare sk- with no suffix is invalid", "Bearer sk-", AuthRoutePublic, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			auth := extractUpstreamAuth(req)
+			if auth.Mode != tt.wantMode {
+				t.Fatalf("mode = %v, want %v", auth.Mode, tt.wantMode)
+			}
+			if auth.Token != tt.wantToken {
+				t.Fatalf("token = %q, want %q", auth.Token, tt.wantToken)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,7 @@ type fakeRetryTransport struct {
 	t               *testing.T
 	responses       []fakeUpstreamResponse
 	requestedModels []string
+	requestedURLs   []string
 	requestPayloads []map[string]any
 	closeIdleCalls  int
 }
@@ -58,6 +59,7 @@ func (f *fakeRetryTransport) RoundTrip(req *http.Request) (*http.Response, error
 	}
 	model, _ := payload["model"].(string)
 	f.requestedModels = append(f.requestedModels, model)
+	f.requestedURLs = append(f.requestedURLs, req.URL.String())
 	f.requestPayloads = append(f.requestPayloads, payload)
 
 	next := f.responses[0]
@@ -208,6 +210,58 @@ func TestCallOpenCodeAPIRetries4xxAndClosesConnectionBeforeRetry(t *testing.T) {
 			}
 			if transport.closeIdleCalls != tt.wantCloses {
 				t.Fatalf("CloseIdleConnections calls = %d, want %d", transport.closeIdleCalls, tt.wantCloses)
+			}
+		})
+	}
+}
+
+func TestCallOpenCodeAPIFallbackKeepsOriginalGoEndpoint(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non-stream", stream: false},
+		{name: "stream", stream: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{
+				{status: http.StatusUnauthorized, body: `{"error":"unauthorized"}`},
+				{status: http.StatusOK, body: `{"id":"chatcmpl_test","choices":[]}`},
+			})
+			modelMu.Lock()
+			modelsCache = []ModelInfo{{ID: "shared-model"}}
+			goModelsCache = []ModelInfo{{ID: "go-only-model"}, {ID: "shared-model"}}
+			modelMu.Unlock()
+
+			auth := UpstreamAuth{Mode: AuthRouteAuto, Token: "sk-validkey0123456789abcdef"}
+			body := []byte(`{"model":"go-only-model","messages":[]}`)
+			if tt.stream {
+				body = []byte(`{"model":"go-only-model","messages":[],"stream":true}`)
+				respBody, status, _, err := callOpenCodeAPIStream(body, "go-only-model", auth)
+				if respBody != nil {
+					defer respBody.Close()
+				}
+				if err != nil {
+					t.Fatalf("callOpenCodeAPIStream() error = %v", err)
+				}
+				if status != http.StatusOK {
+					t.Fatalf("callOpenCodeAPIStream() status = %d, want %d", status, http.StatusOK)
+				}
+			} else {
+				_, status, _, err := callOpenCodeAPI(body, "go-only-model", auth)
+				if err != nil {
+					t.Fatalf("callOpenCodeAPI() error = %v", err)
+				}
+				if status != http.StatusOK {
+					t.Fatalf("callOpenCodeAPI() status = %d, want %d", status, http.StatusOK)
+				}
+			}
+
+			wantURL := "https://opencode.ai/zen/go/v1/chat/completions"
+			if !reflect.DeepEqual(transport.requestedURLs, []string{wantURL, wantURL}) {
+				t.Fatalf("requested URLs = %#v, want both requests to %q", transport.requestedURLs, wantURL)
 			}
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -98,7 +98,7 @@ func installFakeOpenCodeClient(t *testing.T, responses []fakeUpstreamResponse) *
 	httpClient = &http.Client{Transport: transport}
 
 	modelMu.Lock()
-	modelsCache = []ModelInfo{{ID: "fallback-model"}}
+	modelsCache = []ModelInfo{{ID: "fallback-model-free"}}
 	goModelsCache = nil
 	modelMu.Unlock()
 
@@ -154,7 +154,7 @@ func TestCallOpenCodeAPIRetries4xxAndClosesConnectionBeforeRetry(t *testing.T) {
 			},
 			wantStatus:  http.StatusOK,
 			wantBody:    `{"id":"chatcmpl_test","choices":[]}`,
-			wantModels:  []string{"primary-model", "fallback-model"},
+			wantModels:  []string{"primary-model", "fallback-model-free"},
 			wantCloses:  1,
 			requestBody: `{"model":"primary-model","messages":[]}`,
 		},
@@ -167,7 +167,7 @@ func TestCallOpenCodeAPIRetries4xxAndClosesConnectionBeforeRetry(t *testing.T) {
 			},
 			wantStatus:  http.StatusOK,
 			wantBody:    "data: ok\n\n",
-			wantModels:  []string{"primary-model", "fallback-model"},
+			wantModels:  []string{"primary-model", "fallback-model-free"},
 			wantCloses:  1,
 			requestBody: `{"model":"primary-model","messages":[],"stream":true}`,
 		},
@@ -240,7 +240,7 @@ func TestCallOpenCodeAPIExhausted4xxReturnsLastUpstreamResponse(t *testing.T) {
 	if header.Get("X-Upstream-Error") != "last" {
 		t.Fatalf("final header = %q, want last", header.Get("X-Upstream-Error"))
 	}
-	wantModels := []string{"primary-model", "fallback-model"}
+	wantModels := []string{"primary-model", "fallback-model-free"}
 	if !reflect.DeepEqual(transport.requestedModels, wantModels) {
 		t.Fatalf("requested models = %#v, want %#v", transport.requestedModels, wantModels)
 	}


### PR DESCRIPTION
## 背景

实际使用中发现两类 401 问题，根因都在代理层而非上游。

## 修复内容

### 1. 模型回退按认证权限过滤

**现象：** 请求一个模型失败后，日志里出现 `claude-fable-5`、`claude-opus-4-8` 等不在 `/v1/models` 列表中的模型被逐个尝试，全部返回 401，白白消耗请求。

**原因：** `callOpenCodeAPI` / `callOpenCodeAPIStream` 的回退候选来自 `getModelIDs()`，而它返回上游 `modelsCache` 的**全部模型**（50 个，含付费模型）。但对外 `/v1/models` 接口在 public 模式下已过滤为只返回 `-free` 模型——回退路径和列表接口的可见范围不一致。

**修复：** 新增 `getCandidateModels(auth, modelID)`，回退候选与当前请求的认证权限对齐：
- public 模式只回退到 `-free` 模型
- 带 key 的模式只回退到与目标模型走相同端点（zen/go）的模型，避免跨目录 401

### 2. API key 只认 sk- 前缀

**现象：** 部分客户端（如通过 OpenAI 兼容接口接入的 Hermes Agent）在没有真实 key 时会发送占位 key（如 `no-key-required`），代理原样透传给上游，必然返回 `401 Invalid API key`。

**原因：** `extractUpstreamAuth` 只判断 token 是否为空或 `public`，其余一律当有效 key 走 Auto 模式透传。

**修复：** 新增 `isValidOpenCodeKey`（`sk-` 前缀 + 长度校验），只有格式合法的 key 才透传给上游，其余回退到 public 模式。`go:`/`zen:` 前缀路由同样要求去掉前缀后剩余部分是有效 key。

### 3. 文档同步

README 认证模式补充说明：无效或占位 key 会自动回退到 public 模式。

## 测试

- `go test ./...` 全绿
- 新增 `TestExtractUpstreamAuthKeyValidation`（10 个用例），锁定空 key、占位 key、无效 key、有效 sk- key、go/zen 前缀等边界
- 现有回退测试的 `fallback-model` 改为 `fallback-model-free`，反映 public 只回退 free 模型的新行为
- 端到端实测：`no-key-required`、无效 key、`go:no-key-required` 均从 401 变为 200