### PR TITLE
fix: improve protocol compatibility and model aliases

### DIFF
--- a/anthropic_protocol.go
+++ b/anthropic_protocol.go
@@ -1,0 +1,44 @@
+package main
+
+// convertClaudeRequest is the request-side protocol boundary. It returns a new
+// Chat Completions request and never mutates values owned by the caller.
+func convertClaudeRequest(req ClaudeRequest) OpenAIRequest {
+	out := OpenAIRequest{
+		Model: req.Model, Messages: claudeToOpenAIMessages(req.Messages, req.System),
+		Stream: req.Stream, Temperature: req.Temperature, MaxTokens: req.MaxTokens,
+		TopP: req.TopP, Tools: claudeToOpenAITools(req.Tools),
+		ToolChoice: convertClaudeToolChoice(req.ToolChoice),
+	}
+	if len(req.StopSequences) > 0 {
+		out.ExtraBody = map[string]any{"stop": append([]string(nil), req.StopSequences...)}
+	}
+	if metadata, ok := req.Metadata.(map[string]any); ok {
+		if user, ok := metadata["user_id"].(string); ok && user != "" {
+			if out.ExtraBody == nil {
+				out.ExtraBody = map[string]any{}
+			}
+			out.ExtraBody["user"] = user
+		}
+	}
+	return out
+}
+
+func convertClaudeToolChoice(choice any) any {
+	m, ok := choice.(map[string]any)
+	if !ok {
+		return choice
+	}
+	switch m["type"] {
+	case "auto":
+		return "auto"
+	case "any":
+		return "required"
+	case "none":
+		return "none"
+	case "tool":
+		if name, ok := m["name"].(string); ok && name != "" {
+			return map[string]any{"type": "function", "function": map[string]any{"name": name}}
+		}
+	}
+	return choice
+}

--- a/anthropic_protocol.go
+++ b/anthropic_protocol.go
@@ -9,8 +9,17 @@ func convertClaudeRequest(req ClaudeRequest) OpenAIRequest {
 		TopP: req.TopP, Tools: claudeToOpenAITools(req.Tools),
 		ToolChoice: convertClaudeToolChoice(req.ToolChoice),
 	}
+	if req.TopK != nil {
+		if out.ExtraBody == nil {
+			out.ExtraBody = map[string]any{}
+		}
+		out.ExtraBody["top_k"] = *req.TopK
+	}
 	if len(req.StopSequences) > 0 {
-		out.ExtraBody = map[string]any{"stop": append([]string(nil), req.StopSequences...)}
+		if out.ExtraBody == nil {
+			out.ExtraBody = map[string]any{}
+		}
+		out.ExtraBody["stop"] = append([]string(nil), req.StopSequences...)
 	}
 	if metadata, ok := req.Metadata.(map[string]any); ok {
 		if user, ok := metadata["user_id"].(string); ok && user != "" {

--- a/chat_protocol.go
+++ b/chat_protocol.go
@@ -1,0 +1,55 @@
+package main
+
+// normalizeFinishReason maps Anthropic stop reasons onto the closed set used
+// by Chat Completions.
+func normalizeFinishReason(reason string) string {
+	switch reason {
+	case "end_turn", "stop_sequence", "stop":
+		return "stop"
+	case "max_tokens", "length":
+		return "length"
+	case "tool_use", "tool_calls", "function_call":
+		return "tool_calls"
+	case "refusal", "content_filter":
+		return "content_filter"
+	default:
+		return reason
+	}
+}
+
+func anthropicUsageToChat(usage map[string]any) map[string]any {
+	if usage == nil {
+		return nil
+	}
+	out := make(map[string]any, len(usage)+3)
+	for k, v := range usage {
+		out[k] = v
+	}
+	if v, ok := usage["input_tokens"]; ok {
+		out["prompt_tokens"] = v
+	}
+	if v, ok := usage["output_tokens"]; ok {
+		out["completion_tokens"] = v
+	}
+	if p, pok := numberAsFloat(out["prompt_tokens"]); pok {
+		if c, cok := numberAsFloat(out["completion_tokens"]); cok {
+			out["total_tokens"] = p + c
+		}
+	}
+	delete(out, "input_tokens")
+	delete(out, "output_tokens")
+	return out
+}
+
+func numberAsFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,11 @@
 {
   "model_alias": {
-    "gpt-4o-mini": "deepseek-v4-flash-free"
+    "deepseek-v4-flash": "deepseek-v4-flash-free",
+    "mimo-v2.5": "mimo-v2.5-free",
+    "ling-3.0-flash": "ling-3.0-flash-free",
+    "nemotron-3-ultra": "nemotron-3-ultra-free",
+    "north-mini-code": "north-mini-code-free",
+    "laguna-s-2.1": "laguna-s-2.1-free"
   },
   "reasoning_effort_map": {
     "minimal": "low",

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,12 @@ if [ ! -f "$OPENCODE2API_CONFIG" ]; then
     cat > "$OPENCODE2API_CONFIG" <<EOF
 {
   "model_alias": {
-    "gpt-4o-mini": "deepseek-v4-flash-free"
+    "deepseek-v4-flash": "deepseek-v4-flash-free",
+    "mimo-v2.5": "mimo-v2.5-free",
+    "ling-3.0-flash": "ling-3.0-flash-free",
+    "nemotron-3-ultra": "nemotron-3-ultra-free",
+    "north-mini-code": "north-mini-code-free",
+    "laguna-s-2.1": "laguna-s-2.1-free"
   },
   "reasoning_effort_map": {
     "minimal": "low",

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,7 @@
 
 | 路由 | 方法 | 说明 |
 | --- | --- | --- |
-| `/v1/models` | `GET` | 返回上游模型和本地别名模型 |
+| `/v1/models` | `GET` | 返回权限范围内的模型；已配置别名会替换对应上游模型 ID |
 | `/v1/chat/completions` | `POST` | OpenAI Chat Completions 兼容入口 |
 | `/v1/responses` | `POST` | OpenAI Responses 兼容入口 |
 | `/v1/messages` | `POST` | Anthropic Messages 兼容入口 |
@@ -68,11 +68,12 @@
 
 ### 准确支持
 
-- `input`、`instructions`、`messages`、`previous_response_id`
+- 字符串 `input`；含 `input_text` / `input_image` 的 message item；函数及内置工具的 call/output item
+- `instructions`、`messages`、`previous_response_id`
 - 显式零值的 `temperature`、`top_p`、`frequency_penalty`、`presence_penalty`
-- `max_output_tokens`、`stop`、`user`、`parallel_tool_calls`、`stream_options`
+- `max_output_tokens`、`stop`、`user`、`parallel_tool_calls`、`stream_options`、`store`
 - 函数工具、项目已有的内置工具、`tool_choice`、`reasoning`、`metadata`
-- 正常终态 `response.completed`；长度截断终态 `response.incomplete`，reason 为 `max_tokens`
+- 正常终态 `response.completed`；长度截断终态 `response.incomplete`，reason 为 `max_output_tokens`
 
 ### Best-effort
 
@@ -81,7 +82,8 @@
 
 ### 不支持
 
-- 未在上面列出的可选 Responses 字段不会用占位值伪装成已支持。
+- `input_file` 等未在准确支持列表中的 input item 类型。
+- `include` 及未在上面列出的可选 Responses 字段；这些字段不会用占位值伪装成已支持。
 
 示例：
 
@@ -99,8 +101,8 @@ curl http://127.0.0.1:8000/v1/responses \
 
 ### 准确支持
 
-- `system`、`stop_sequences`、采样参数（包括显式零值）和 `metadata.user_id`
-- 文本、base64/URL image、`tool_use`、`tool_result`（包括 `is_error`）
+- `system`、`stop_sequences`、`temperature` / `top_p` / `top_k`（包括显式零值）和 `metadata.user_id`
+- 文本、base64/URL image、`tool_use`、`tool_result`（包括 `is_error`）；合法的 tool result 在普通用户内容之前的顺序会被保留
 - `tool_choice` 的 `auto`、`any`、`tool`、`none`
 - JSON Schema 约束字段（包括 `additionalProperties`、`format`）
 - stop reason、usage 以及流式 content block 配对

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@
 
 ## Chat Completions
 
-支持常见字段：
+### 准确支持
 
 - `model`
 - `messages`
@@ -51,11 +51,37 @@
 - `tools`
 - `tool_choice`
 
+流式响应会原样保留合法的 usage-only 尾块（`choices: []`）以及完整 usage details。
+
+### Best-effort
+
+- 上游 Anthropic 响应会转换 stop reason、usage、reasoning、refusal 和工具调用。
+- 不同上游模型对 `thinking` / `reasoning_effort` 的支持可能不同。
+
+### 不支持
+
+- 本项目未声明支持的 Chat Completions beta 字段不会被合成或伪造。
+
 `model` 会先经过 `model_alias` 解析。`reasoning_effort` 会按 `reasoning_effort_map` 转换。
 
 ## Responses API
 
-支持从 `input`、`instructions` 或 `messages` 转换为 Chat Completions 形状。函数调用输出会尽量映射到 OpenAI tool message。
+### 准确支持
+
+- `input`、`instructions`、`messages`、`previous_response_id`
+- 显式零值的 `temperature`、`top_p`、`frequency_penalty`、`presence_penalty`
+- `max_output_tokens`、`stop`、`user`、`parallel_tool_calls`、`stream_options`
+- 函数工具、项目已有的内置工具、`tool_choice`、`reasoning`、`metadata`
+- 正常终态 `response.completed`；长度截断终态 `response.incomplete`，reason 为 `max_tokens`
+
+### Best-effort
+
+- Responses 会通过 Chat Completions 上游实现；内置工具被编码为函数工具后再还原。
+- 仅在上游实际返回 reasoning 时生成 reasoning output item。
+
+### 不支持
+
+- 未在上面列出的可选 Responses 字段不会用占位值伪装成已支持。
 
 示例：
 
@@ -71,7 +97,22 @@ curl http://127.0.0.1:8000/v1/responses \
 
 ## Anthropic Messages
 
-支持 `system`、文本消息、base64 image block、thinking block、tool_use 和 tool_result 的基础转换。
+### 准确支持
+
+- `system`、`stop_sequences`、采样参数（包括显式零值）和 `metadata.user_id`
+- 文本、base64/URL image、`tool_use`、`tool_result`（包括 `is_error`）
+- `tool_choice` 的 `auto`、`any`、`tool`、`none`
+- JSON Schema 约束字段（包括 `additionalProperties`、`format`）
+- stop reason、usage 以及流式 content block 配对
+
+### Best-effort
+
+- thinking 会在没有 signature 时继续输出，以提高客户端兼容性。代理不会伪造 signature 或发送假的 `signature_delta`。
+- `redacted_thinking.data` 是不可解释的加密数据，无法无损转成 reasoning；代理忽略该内容且不记录其数据。
+
+### 不支持
+
+- Anthropic beta、server tools、fallback 等本项目未承诺的扩展。
 
 示例：
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,7 +15,12 @@ cp config.example.json config.json
 ```json
 {
   "model_alias": {
-    "gpt-4o-mini": "deepseek-v4-flash-free"
+    "deepseek-v4-flash": "deepseek-v4-flash-free",
+    "mimo-v2.5": "mimo-v2.5-free",
+    "ling-3.0-flash": "ling-3.0-flash-free",
+    "nemotron-3-ultra": "nemotron-3-ultra-free",
+    "north-mini-code": "north-mini-code-free",
+    "laguna-s-2.1": "laguna-s-2.1-free"
   }
 }
 ```

--- a/main.go
+++ b/main.go
@@ -752,6 +752,7 @@ type ClaudeRequest struct {
 	MaxTokens     *int            `json:"max_tokens,omitempty"`
 	Temperature   *float64        `json:"temperature,omitempty"`
 	TopP          *float64        `json:"top_p,omitempty"`
+	TopK          *int            `json:"top_k,omitempty"`
 	Stream        bool            `json:"stream,omitempty"`
 	Tools         []ClaudeTool    `json:"tools,omitempty"`
 	ToolChoice    any             `json:"tool_choice,omitempty"`
@@ -2241,8 +2242,18 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 			if len(toolCalls) > 0 {
 				om.ToolCalls = toolCalls
 			}
-			messages = append(messages, om)
-			messages = append(messages, toolResults...)
+			// Anthropic requires tool_result blocks to precede ordinary user
+			// content. Preserve that order when translating them to Chat
+			// Completions' separate tool messages.
+			if msg.Role == "user" {
+				messages = append(messages, toolResults...)
+			}
+			if len(orderedContent) > 0 || len(reasoningParts) > 0 || len(toolCalls) > 0 || len(toolResults) == 0 {
+				messages = append(messages, om)
+			}
+			if msg.Role != "user" {
+				messages = append(messages, toolResults...)
+			}
 		default:
 			b, _ := json.Marshal(content)
 			messages = append(messages, Message{Role: msg.Role, Content: string(b)})
@@ -2581,6 +2592,7 @@ func claudeStreamHandler(w http.ResponseWriter, respBody io.ReadCloser, model st
 	thinkingBlockOpen := false
 	textBlockOpen := false
 	toolCallAccumulator := map[int]map[string]string{}
+	toolBlockIndices := map[int]int{}
 	toolCallOrder := []int{}
 	messageStartSent := false
 	fullUsage := map[string]any{}
@@ -2766,6 +2778,7 @@ func claudeStreamHandler(w http.ResponseWriter, respBody io.ReadCloser, model st
 						"args": "",
 					}
 					toolCallOrder = append(toolCallOrder, upstreamIndex)
+					toolBlockIndices[upstreamIndex] = blockIndex
 					emitClaudeEvent("content_block_start", map[string]any{
 						"type":  "content_block_start",
 						"index": blockIndex,
@@ -2784,7 +2797,7 @@ func claudeStreamHandler(w http.ResponseWriter, respBody io.ReadCloser, model st
 					toolCallAccumulator[upstreamIndex]["args"] += argDelta
 					emitClaudeEvent("content_block_delta", map[string]any{
 						"type":  "content_block_delta",
-						"index": blockIndex - 1,
+						"index": toolBlockIndices[upstreamIndex],
 						"delta": map[string]any{
 							"type":         "input_json_delta",
 							"partial_json": argDelta,
@@ -2802,7 +2815,7 @@ func claudeStreamHandler(w http.ResponseWriter, respBody io.ReadCloser, model st
 				acc := toolCallAccumulator[idx]
 				emitClaudeEvent("content_block_stop", map[string]any{
 					"type":  "content_block_stop",
-					"index": blockIndex - len(toolCallOrder) + indexOfInt(toolCallOrder, idx),
+					"index": toolBlockIndices[idx],
 					"content_block": map[string]any{
 						"type":  "tool_use",
 						"id":    acc["id"],
@@ -3278,6 +3291,9 @@ func cloneJSONValue[T any](value T) T {
 }
 
 func storeResponseState(response map[string]any, req ResponsesAPIRequest) {
+	if req.Store != nil && !*req.Store {
+		return
+	}
 	responseID, _ := response["id"].(string)
 	if responseID == "" {
 		return
@@ -3788,7 +3804,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			"type":            "response.output_item.done",
 			"sequence_number": seq,
 			"output_index":    reasoningOutputIndex,
-			"item":            reasoningItem("completed"),
+			"item":            reasoningItem(itemStatus),
 		})
 		reasoningDone = true
 	}
@@ -3822,7 +3838,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			"type":            "response.output_item.done",
 			"sequence_number": seq,
 			"output_index":    idx,
-			"item":            messageItem("completed"),
+			"item":            messageItem(itemStatus),
 		})
 		messageDone = true
 	}
@@ -3850,11 +3866,13 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 		if itemType == "" {
 			itemType = "function_call"
 		}
+		item := buildResponseToolCallItem(ToolCall{ID: callID, Function: FunctionCall{Name: name, Arguments: args}}, itemType)
+		item["status"] = itemStatus
 		emitSSEEvent(w, flusher, "response.output_item.done", map[string]any{
 			"type":            "response.output_item.done",
 			"sequence_number": seq,
 			"output_index":    idx,
-			"item":            buildResponseToolCallItem(ToolCall{ID: callID, Function: FunctionCall{Name: name, Arguments: args}}, itemType),
+			"item":            item,
 		})
 	}
 
@@ -3959,7 +3977,9 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			contentStr, _ = c.(string)
 		}
 		if contentStr != "" {
-			emitReasoningDone()
+			// The terminal finish reason determines the item's final status. Keep the
+			// reasoning item open until that reason is known so a truncation cannot
+			// first announce it as completed.
 			if !messageStarted {
 				idx := messageOutputIndex()
 				seq++
@@ -4136,7 +4156,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 		"output":             output,
 	}
 	if terminalStatus == "incomplete" {
-		completedResponse["incomplete_details"] = map[string]any{"reason": "max_tokens"}
+		completedResponse["incomplete_details"] = map[string]any{"reason": "max_output_tokens"}
 	}
 	applyResponsesRequestEcho(completedResponse, originalReq)
 	if len(tools) > 0 {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1980,18 +1981,13 @@ func listModelsHandler(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	// 追加别名模型
+	// 保存别名快照；目录权限仍按真实上游模型判断，最后再替换为客户端可见名称。
 	configMu.RLock()
-	aliases := make([]string, 0, len(modelAlias))
-	for k := range modelAlias {
-		aliases = append(aliases, k)
+	aliases := make(map[string]string, len(modelAlias))
+	for alias, upstream := range modelAlias {
+		aliases[alias] = upstream
 	}
 	configMu.RUnlock()
-	now := time.Now().Unix()
-	aliasModels := make([]ModelInfo, 0, len(aliases))
-	for _, alias := range aliases {
-		aliasModels = append(aliasModels, ModelInfo{ID: alias, Object: "model", Created: now, OwnedBy: "alias"})
-	}
 
 	auth := extractUpstreamAuth(r)
 	var combinedModels []ModelInfo
@@ -2024,24 +2020,50 @@ func listModelsHandler(w http.ResponseWriter, r *http.Request) {
 	default:
 		combinedModels = models
 	}
-	allModels := append(combinedModels, aliasModels...)
-	if auth.Mode == AuthRoutePublic {
-		filtered := make([]ModelInfo, 0, len(allModels))
-		for _, m := range allModels {
-			if isFreeModel(m.ID) {
-				filtered = append(filtered, m)
-			}
-		}
-		if len(filtered) > 0 {
-			allModels = filtered
-		}
-	}
+	allModels := replaceModelIDsWithAliases(combinedModels, aliases)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		"object": "list",
 		"data":   allModels,
 	})
+}
+
+func replaceModelIDsWithAliases(models []ModelInfo, aliases map[string]string) []ModelInfo {
+	aliasesByUpstream := make(map[string][]string, len(aliases))
+	for alias, upstream := range aliases {
+		alias = strings.TrimSpace(alias)
+		upstream = strings.TrimSpace(upstream)
+		if alias == "" || upstream == "" {
+			continue
+		}
+		aliasesByUpstream[upstream] = append(aliasesByUpstream[upstream], alias)
+	}
+	for upstream := range aliasesByUpstream {
+		sort.Strings(aliasesByUpstream[upstream])
+	}
+
+	result := make([]ModelInfo, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		visibleIDs := aliasesByUpstream[model.ID]
+		if len(visibleIDs) == 0 {
+			visibleIDs = []string{model.ID}
+		}
+		for _, visibleID := range visibleIDs {
+			if _, exists := seen[visibleID]; exists {
+				continue
+			}
+			visibleModel := model
+			visibleModel.ID = visibleID
+			if visibleID != model.ID {
+				visibleModel.OwnedBy = "alias"
+			}
+			result = append(result, visibleModel)
+			seen[visibleID] = struct{}{}
+		}
+	}
+	return result
 }
 
 // ======================== Claude Messages API ========================

--- a/main.go
+++ b/main.go
@@ -694,7 +694,7 @@ type OpenAIRequest struct {
 	Messages        []Message      `json:"messages"`
 	Stream          bool           `json:"stream"`
 	Temperature     *float64       `json:"temperature,omitempty"`
-	MaxTokens       int            `json:"max_tokens,omitempty"`
+	MaxTokens       *int           `json:"max_tokens,omitempty"`
 	TopP            *float64       `json:"top_p,omitempty"`
 	Thinking        any            `json:"thinking,omitempty"`
 	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
@@ -745,17 +745,18 @@ type AppConfig struct {
 // ======================== Claude Messages API 类型 ========================
 
 type ClaudeRequest struct {
-	Model       string          `json:"model"`
-	Messages    []ClaudeMessage `json:"messages"`
-	System      any             `json:"system,omitempty"`
-	MaxTokens   int             `json:"max_tokens,omitempty"`
-	Temperature *float64        `json:"temperature,omitempty"`
-	TopP        *float64        `json:"top_p,omitempty"`
-	Stream      bool            `json:"stream,omitempty"`
-	Tools       []ClaudeTool    `json:"tools,omitempty"`
-	ToolChoice  any             `json:"tool_choice,omitempty"`
-	Metadata    any             `json:"metadata,omitempty"`
-	Thinking    any             `json:"thinking,omitempty"`
+	Model         string          `json:"model"`
+	Messages      []ClaudeMessage `json:"messages"`
+	System        any             `json:"system,omitempty"`
+	MaxTokens     *int            `json:"max_tokens,omitempty"`
+	Temperature   *float64        `json:"temperature,omitempty"`
+	TopP          *float64        `json:"top_p,omitempty"`
+	Stream        bool            `json:"stream,omitempty"`
+	Tools         []ClaudeTool    `json:"tools,omitempty"`
+	ToolChoice    any             `json:"tool_choice,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
+	Metadata      any             `json:"metadata,omitempty"`
+	Thinking      any             `json:"thinking,omitempty"`
 }
 
 type ClaudeMessage struct {
@@ -802,11 +803,11 @@ type ResponsesAPIRequest struct {
 	Instructions       string          `json:"instructions,omitempty"`
 	PreviousResponseID string          `json:"previous_response_id,omitempty"`
 	Stream             bool            `json:"stream,omitempty"`
-	Temperature        float64         `json:"temperature,omitempty"`
-	MaxTokens          int             `json:"max_output_tokens,omitempty"`
-	TopP               float64         `json:"top_p,omitempty"`
-	FrequencyPenalty   float64         `json:"frequency_penalty,omitempty"`
-	PresencePenalty    float64         `json:"presence_penalty,omitempty"`
+	Temperature        *float64        `json:"temperature,omitempty"`
+	MaxTokens          *int            `json:"max_output_tokens,omitempty"`
+	TopP               *float64        `json:"top_p,omitempty"`
+	FrequencyPenalty   *float64        `json:"frequency_penalty,omitempty"`
+	PresencePenalty    *float64        `json:"presence_penalty,omitempty"`
 	Reasoning          ReasonEffort    `json:"reasoning,omitempty"`
 	Include            []string        `json:"include,omitempty"`
 	Store              *bool           `json:"store,omitempty"`
@@ -1115,8 +1116,8 @@ func convertRequest(req *OpenAIRequest) map[string]any {
 	if req.Temperature != nil {
 		converted["temperature"] = *req.Temperature
 	}
-	if req.MaxTokens != 0 {
-		converted["max_tokens"] = req.MaxTokens
+	if req.MaxTokens != nil {
+		converted["max_tokens"] = *req.MaxTokens
 	}
 	if req.TopP != nil {
 		converted["top_p"] = *req.TopP
@@ -1279,9 +1280,7 @@ func buildOpenAIResponse(anthropicMsg map[string]any, text string, toolUseBlocks
 		role = "assistant"
 	}
 	finishReason, _ := anthropicMsg["stop_reason"].(string)
-	if finishReason == "tool_use" {
-		finishReason = "tool_calls"
-	}
+	finishReason = normalizeFinishReason(finishReason)
 	choice := map[string]any{
 		"index":         0,
 		"message":       map[string]any{"role": role, "content": text},
@@ -1313,8 +1312,8 @@ func buildOpenAIResponse(anthropicMsg map[string]any, text string, toolUseBlocks
 		"model":   modelID,
 		"choices": []map[string]any{choice},
 	}
-	if usage, ok := anthropicMsg["usage"]; ok {
-		resp["usage"] = usage
+	if usage, ok := anthropicMsg["usage"].(map[string]any); ok {
+		resp["usage"] = anthropicUsageToChat(usage)
 	}
 	result, _ := json.Marshal(resp)
 	return result
@@ -1419,7 +1418,14 @@ func convertStreamChunkWithUsage(line string, keepReasoning bool) (string, map[s
 
 	choices, ok := raw["choices"].([]any)
 	if !ok || len(choices) == 0 {
-		return "", usage
+		// Chat Completions deliberately uses an empty choices array for the
+		// terminal usage chunk. It is part of the client-visible stream.
+		delete(raw, "cost")
+		converted, err := json.Marshal(raw)
+		if err != nil {
+			return line, usage
+		}
+		return "data: " + string(converted), usage
 	}
 	for i, c := range choices {
 		choice, ok := c.(map[string]any)
@@ -1484,16 +1490,7 @@ func convertResponse(data []byte, keepReasoning bool) ([]byte, error) {
 		}
 		raw["choices"] = choices
 	}
-	if usage, ok := raw["usage"].(map[string]any); ok {
-		cleanU := map[string]any{
-			"prompt_tokens":     usage["prompt_tokens"],
-			"completion_tokens": usage["completion_tokens"],
-			"total_tokens":      usage["total_tokens"],
-		}
-		raw["usage"] = cleanU
-	}
 	delete(raw, "cost")
-	delete(raw, "system_fingerprint")
 	return json.Marshal(raw)
 }
 
@@ -2079,27 +2076,27 @@ func cleanJsonSchema(schema any) any {
 	if !ok {
 		return schema
 	}
-	delete(m, "$schema")
-	delete(m, "title")
-	delete(m, "examples")
-	delete(m, "additionalProperties")
-	if m["type"] == "string" {
-		delete(m, "format")
-	}
+	clean := make(map[string]any, len(m))
 	for k, v := range m {
-		if sub, ok := v.(map[string]any); ok {
-			m[k] = cleanJsonSchema(sub)
+		// Annotation-only keys are omitted for upstream compatibility. Constraint
+		// keys such as additionalProperties and format are preserved.
+		if k == "$schema" || k == "title" || k == "examples" {
+			continue
 		}
-		if arr, ok := v.([]any); ok {
-			for i, elem := range arr {
-				if sub, ok := elem.(map[string]any); ok {
-					arr[i] = cleanJsonSchema(sub)
-				}
+		switch child := v.(type) {
+		case map[string]any:
+			clean[k] = cleanJsonSchema(child)
+		case []any:
+			copyArray := make([]any, len(child))
+			for i, elem := range child {
+				copyArray[i] = cleanJsonSchema(elem)
 			}
-			m[k] = arr
+			clean[k] = copyArray
+		default:
+			clean[k] = v
 		}
 	}
-	return m
+	return clean
 }
 
 func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
@@ -2112,11 +2109,10 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 		case string:
 			messages = append(messages, Message{Role: msg.Role, Content: content})
 		case []any:
-			var textParts []string
+			var orderedContent []any
 			var reasoningParts []string
 			var toolCalls []ToolCall
 			var toolResults []Message
-			var imageParts []map[string]any
 			for _, item := range content {
 				block, ok := item.(map[string]any)
 				if !ok {
@@ -2126,7 +2122,7 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 				switch blockType {
 				case "text":
 					if text, ok := block["text"].(string); ok && text != "" {
-						textParts = append(textParts, text)
+						orderedContent = append(orderedContent, map[string]any{"type": "text", "text": text})
 					}
 				case "image":
 					source, _ := block["source"].(map[string]any)
@@ -2134,11 +2130,15 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 						srcType, _ := source["type"].(string)
 						mediaType, _ := source["media_type"].(string)
 						data, _ := source["data"].(string)
+						url, _ := source["url"].(string)
+						if srcType == "url" && url != "" {
+							orderedContent = append(orderedContent, map[string]any{"type": "image_url", "image_url": map[string]string{"url": url}})
+						}
 						if srcType == "base64" && data != "" {
 							if mediaType == "" {
 								mediaType = "image/png"
 							}
-							imageParts = append(imageParts, map[string]any{
+							orderedContent = append(orderedContent, map[string]any{
 								"type": "image_url",
 								"image_url": map[string]string{
 									"url": "data:" + mediaType + ";base64," + data,
@@ -2196,6 +2196,9 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 							resultText = string(b)
 						}
 					}
+					if isError, _ := block["is_error"].(bool); isError {
+						resultText = "Error: " + resultText
+					}
 					toolResults = append(toolResults, Message{
 						Role:       "tool",
 						ToolCallID: toolUseID,
@@ -2204,20 +2207,8 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 				}
 			}
 			om := Message{Role: msg.Role}
-			if len(imageParts) > 0 {
-				var contentArr []any
-				for _, img := range imageParts {
-					contentArr = append(contentArr, img)
-				}
-				if len(textParts) > 0 {
-					contentArr = append(contentArr, map[string]any{
-						"type": "text",
-						"text": strings.Join(textParts, "\n"),
-					})
-				}
-				om.Content = contentArr
-			} else if len(textParts) > 0 {
-				om.Content = strings.Join(textParts, "\n")
+			if len(orderedContent) > 0 {
+				om.Content = orderedContent
 			} else if len(toolCalls) == 0 {
 				om.Content = ""
 			}
@@ -2246,12 +2237,16 @@ func claudeToOpenAITools(claudeTools []ClaudeTool) []Tool {
 			params = map[string]any{"type": "object", "properties": map[string]any{}}
 		}
 		params = cleanJsonSchema(params)
+		paramsMap, ok := params.(map[string]any)
+		if !ok {
+			paramsMap = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
 		tools = append(tools, Tool{
 			Type: "function",
 			Function: ToolFunction{
 				Name:        ct.Name,
 				Description: ct.Description,
-				Parameters:  params.(map[string]any),
+				Parameters:  paramsMap,
 			},
 		})
 	}
@@ -2315,6 +2310,8 @@ func openAIToClaudeResponse(chatBody []byte, model string, wantReasoning bool) [
 			stopReason = "max_tokens"
 		case "tool_calls", "function_call":
 			stopReason = "tool_use"
+		case "content_filter":
+			stopReason = "refusal"
 		}
 	}
 
@@ -2478,31 +2475,13 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 
 	// 多模态路由
 
-	messages := claudeToOpenAIMessages(claudeReq.Messages, claudeReq.System)
-	messages = fixToolCallGaps(messages)
-
-	chatReq := OpenAIRequest{
-		Model:    claudeReq.Model,
-		Messages: messages,
-		Stream:   claudeReq.Stream,
-	}
+	chatReq := convertClaudeRequest(claudeReq)
+	chatReq.Messages = fixToolCallGaps(chatReq.Messages)
 	if claudeReq.Stream {
-		chatReq.ExtraBody = map[string]any{
-			"stream_options": map[string]any{"include_usage": true},
+		if chatReq.ExtraBody == nil {
+			chatReq.ExtraBody = map[string]any{}
 		}
-	}
-	if claudeReq.MaxTokens > 0 {
-		chatReq.MaxTokens = claudeReq.MaxTokens
-	}
-	if claudeReq.Temperature != nil {
-		chatReq.Temperature = claudeReq.Temperature
-	}
-	if claudeReq.TopP != nil {
-		chatReq.TopP = claudeReq.TopP
-	}
-	if len(claudeReq.Tools) > 0 {
-		chatReq.Tools = claudeToOpenAITools(claudeReq.Tools)
-		chatReq.ToolChoice = "auto"
+		chatReq.ExtraBody["stream_options"] = map[string]any{"include_usage": true}
 	}
 
 	wantReasoning := !getForceDisableThinking()
@@ -2817,6 +2796,8 @@ func claudeStreamHandler(w http.ResponseWriter, respBody io.ReadCloser, model st
 				stopReason = "max_tokens"
 			case "tool_calls", "function_call":
 				stopReason = "tool_use"
+			case "content_filter":
+				stopReason = "refusal"
 			}
 
 			emitClaudeEvent("message_delta", map[string]any{
@@ -3545,14 +3526,14 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 			"stream_options": map[string]any{"include_usage": true},
 		}
 	}
-	if respReq.Temperature != 0 {
-		chatReq.Temperature = &respReq.Temperature
+	if respReq.Temperature != nil {
+		chatReq.Temperature = respReq.Temperature
 	}
-	if respReq.MaxTokens != 0 {
+	if respReq.MaxTokens != nil {
 		chatReq.MaxTokens = respReq.MaxTokens
 	}
-	if respReq.TopP != 0 {
-		chatReq.TopP = &respReq.TopP
+	if respReq.TopP != nil {
+		chatReq.TopP = respReq.TopP
 	}
 	if len(respReq.Tools) > 0 {
 		chatReq.Tools = convertResponsesTools(respReq.Tools)
@@ -3565,6 +3546,30 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 			chatReq.ExtraBody = map[string]any{}
 		}
 		chatReq.ExtraBody["parallel_tool_calls"] = *respReq.ParallelToolCalls
+	}
+	if respReq.Stop != nil {
+		if chatReq.ExtraBody == nil {
+			chatReq.ExtraBody = map[string]any{}
+		}
+		chatReq.ExtraBody["stop"] = respReq.Stop
+	}
+	if respReq.FrequencyPenalty != nil {
+		if chatReq.ExtraBody == nil {
+			chatReq.ExtraBody = map[string]any{}
+		}
+		chatReq.ExtraBody["frequency_penalty"] = *respReq.FrequencyPenalty
+	}
+	if respReq.PresencePenalty != nil {
+		if chatReq.ExtraBody == nil {
+			chatReq.ExtraBody = map[string]any{}
+		}
+		chatReq.ExtraBody["presence_penalty"] = *respReq.PresencePenalty
+	}
+	if respReq.User != "" {
+		if chatReq.ExtraBody == nil {
+			chatReq.ExtraBody = map[string]any{}
+		}
+		chatReq.ExtraBody["user"] = respReq.User
 	}
 	if respReq.StreamOptions != nil {
 		if chatReq.ExtraBody == nil {
@@ -3634,6 +3639,10 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 	responsesBody := convertChatToResponses(respBody, chatReq.Model, wantReasoning, respReq.Tools, respReq.ToolChoice)
 	var responseMap map[string]any
 	if json.Unmarshal(responsesBody, &responseMap) == nil {
+		applyResponsesRequestEcho(responseMap, respReq)
+		if enriched, marshalErr := json.Marshal(responseMap); marshalErr == nil {
+			responsesBody = enriched
+		}
 		storeResponseState(responseMap, respReq)
 	}
 
@@ -3679,15 +3688,21 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 	fullText := ""
 	totalUsage := map[string]any{}
 	createdSent := false
+	terminalStatus := "completed"
+	terminalEvent := "response.completed"
+	itemStatus := "completed"
 	toolCalls := map[int]map[string]any{}
 	toolOrder := []int{}
 	toolKinds := responsesToolKindMap(tools)
+	indexAllocator := outputIndexAllocator{}
+	reasoningOutputIndex := -1
+	messageIndex := -1
 
 	messageOutputIndex := func() int {
-		if reasoningStarted {
-			return 1
+		if messageIndex < 0 {
+			messageIndex = indexAllocator.Allocate()
 		}
-		return 0
+		return messageIndex
 	}
 
 	reasoningItem := func(status string) map[string]any {
@@ -3733,7 +3748,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			"type":            "response.reasoning_summary_text.done",
 			"sequence_number": seq,
 			"item_id":         reasoningID,
-			"output_index":    0,
+			"output_index":    reasoningOutputIndex,
 			"summary_index":   0,
 			"text":            fullReasoning,
 		})
@@ -3742,7 +3757,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			"type":            "response.reasoning_summary_part.done",
 			"sequence_number": seq,
 			"item_id":         reasoningID,
-			"output_index":    0,
+			"output_index":    reasoningOutputIndex,
 			"summary_index":   0,
 			"part":            map[string]any{"type": "summary_text", "text": fullReasoning},
 		})
@@ -3750,7 +3765,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 		emitSSEEvent(w, flusher, "response.output_item.done", map[string]any{
 			"type":            "response.output_item.done",
 			"sequence_number": seq,
-			"output_index":    0,
+			"output_index":    reasoningOutputIndex,
 			"item":            reasoningItem("completed"),
 		})
 		reasoningDone = true
@@ -3805,6 +3820,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			"sequence_number": seq,
 			"item_id":         itemID,
 			"output_index":    idx,
+			"name":            name,
 			"arguments":       args,
 		})
 		seq++
@@ -3884,11 +3900,12 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			rcStr, _ := rc.(string)
 			if rcStr != "" {
 				if !reasoningStarted {
+					reasoningOutputIndex = indexAllocator.Allocate()
 					seq++
 					emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
 						"type":            "response.output_item.added",
 						"sequence_number": seq,
-						"output_index":    0,
+						"output_index":    reasoningOutputIndex,
 						"item":            reasoningItem("in_progress"),
 					})
 					seq++
@@ -3896,7 +3913,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 						"type":            "response.reasoning_summary_part.added",
 						"sequence_number": seq,
 						"item_id":         reasoningID,
-						"output_index":    0,
+						"output_index":    reasoningOutputIndex,
 						"summary_index":   0,
 						"part":            map[string]any{"type": "summary_text", "text": ""},
 					})
@@ -3908,7 +3925,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 					"type":            "response.reasoning_summary_text.delta",
 					"sequence_number": seq,
 					"item_id":         reasoningID,
-					"output_index":    0,
+					"output_index":    reasoningOutputIndex,
 					"summary_index":   0,
 					"delta":           rcStr,
 				})
@@ -3964,11 +3981,7 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			upstreamIndex := int(idxFloat)
 			call, exists := toolCalls[upstreamIndex]
 			if !exists {
-				outputIndex := messageOutputIndex()
-				if messageStarted {
-					outputIndex++
-				}
-				outputIndex += len(toolOrder)
+				outputIndex := indexAllocator.Allocate()
 				callID, _ := tc["id"].(string)
 				if callID == "" {
 					callID = "call_" + randomString(12)
@@ -4026,6 +4039,11 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 			totalUsage = usage
 		}
 		if finishReason == "stop" || finishReason == "length" || finishReason == "content_filter" {
+			if finishReason == "length" {
+				terminalStatus = "incomplete"
+				terminalEvent = "response.incomplete"
+				itemStatus = "incomplete"
+			}
 			emitReasoningDone()
 			if !messageStarted && len(toolCalls) == 0 {
 				idx := messageOutputIndex()
@@ -4060,12 +4078,12 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 		emitToolCallDone(toolCalls[idx]["output_index"].(int), toolCalls[idx])
 	}
 
-	output := []any{}
+	output := make([]any, indexAllocator.Len())
 	if reasoningStarted {
-		output = append(output, reasoningItem("completed"))
+		output[reasoningOutputIndex] = reasoningItem(itemStatus)
 	}
 	if messageStarted {
-		output = append(output, messageItem("completed"))
+		output[messageIndex] = messageItem(itemStatus)
 	}
 	for _, idx := range toolOrder {
 		call := toolCalls[idx]
@@ -4073,26 +4091,32 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 		if itemType == "" {
 			itemType = "function_call"
 		}
-		output = append(output, buildResponseToolCallItem(ToolCall{
+		item := buildResponseToolCallItem(ToolCall{
 			ID: call["call_id"].(string),
 			Function: FunctionCall{
 				Name:      call["name"].(string),
 				Arguments: call["arguments"].(string),
 			},
-		}, itemType))
+		}, itemType)
+		item["status"] = itemStatus
+		output[call["output_index"].(int)] = item
 	}
 
 	completedResponse := map[string]any{
 		"id":                 responseID,
 		"object":             "response",
 		"created_at":         createdAt,
-		"status":             "completed",
+		"status":             terminalStatus,
 		"background":         false,
 		"error":              nil,
 		"incomplete_details": nil,
 		"model":              model,
 		"output":             output,
 	}
+	if terminalStatus == "incomplete" {
+		completedResponse["incomplete_details"] = map[string]any{"reason": "max_tokens"}
+	}
+	applyResponsesRequestEcho(completedResponse, originalReq)
 	if len(tools) > 0 {
 		completedResponse["tools"] = tools
 	}
@@ -4138,8 +4162,8 @@ func responsesStreamHandler(w http.ResponseWriter, _ *http.Request, resp *http.R
 	}
 
 	seq++
-	emitSSEEvent(w, flusher, "response.completed", map[string]any{
-		"type":            "response.completed",
+	emitSSEEvent(w, flusher, terminalEvent, map[string]any{
+		"type":            terminalEvent,
 		"sequence_number": seq,
 		"response":        completedResponse,
 	})
@@ -4158,6 +4182,7 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 			FinishReason string `json:"finish_reason"`
 			Message      struct {
 				Content          any        `json:"content"`
+				Refusal          string     `json:"refusal"`
 				ReasoningContent string     `json:"reasoning_content"`
 				ToolCalls        []ToolCall `json:"tool_calls"`
 			} `json:"message"`
@@ -4175,6 +4200,9 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 	toolKinds := responsesToolKindMap(tools)
 	if len(chat.Choices) > 0 {
 		messageContent, _ = chatContentToResponsesContent(chat.Choices[0].Message.Content)
+		if refusal := chat.Choices[0].Message.Refusal; refusal != "" {
+			messageContent = []any{map[string]any{"type": "refusal", "refusal": refusal}}
+		}
 		if wantReasoning {
 			reasoning = chat.Choices[0].Message.ReasoningContent
 		}
@@ -4182,18 +4210,15 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 		finishReason = chat.Choices[0].FinishReason
 	}
 
-	status := "completed"
-	if finishReason == "length" {
-		status = "incomplete"
-	}
-
+	outcome := responsesOutcome(finishReason)
+	status := outcome.Status
 	responses := map[string]any{
 		"id":                 chat.ID,
 		"object":             "response",
 		"status":             status,
 		"background":         false,
 		"error":              nil,
-		"incomplete_details": nil,
+		"incomplete_details": outcome.IncompleteDetails,
 		"model":              model,
 		"created_at":         chat.Created,
 	}
@@ -4217,13 +4242,15 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 		output = append(output, map[string]any{
 			"id":      outputID,
 			"type":    "message",
-			"status":  "completed",
+			"status":  status,
 			"role":    "assistant",
 			"content": messageContent,
 		})
 	}
 	for _, tc := range toolCalls {
-		output = append(output, buildResponseToolCallItem(tc, toolCallOutputType(tc.Function.Name, toolKinds)))
+		item := buildResponseToolCallItem(tc, toolCallOutputType(tc.Function.Name, toolKinds))
+		item["status"] = status
+		output = append(output, item)
 	}
 	responses["output"] = output
 	if chat.Usage != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -463,6 +463,79 @@ func TestListModelsHandlerSeparatesPublicZenAndGoCatalogs(t *testing.T) {
 	}
 }
 
+func TestListModelsHandlerReplacesMappedModelIDsWithAliases(t *testing.T) {
+	oldModelsCache := modelsCache
+	oldGoModelsCache := goModelsCache
+	oldModelsLoaded := modelsLoaded
+	oldModelAlias := modelAlias
+	modelMu.Lock()
+	modelsCache = []ModelInfo{
+		{ID: "deepseek-v4-flash-free", Object: "model", OwnedBy: "opencode"},
+		{ID: "gpt-5.5", Object: "model", OwnedBy: "opencode"},
+	}
+	goModelsCache = nil
+	modelsLoaded = true
+	modelMu.Unlock()
+	configMu.Lock()
+	modelAlias = map[string]string{
+		"deepseek-v4-flash": "deepseek-v4-flash-free",
+	}
+	configMu.Unlock()
+	t.Cleanup(func() {
+		modelMu.Lock()
+		modelsCache = oldModelsCache
+		goModelsCache = oldGoModelsCache
+		modelsLoaded = oldModelsLoaded
+		modelMu.Unlock()
+		configMu.Lock()
+		modelAlias = oldModelAlias
+		configMu.Unlock()
+	})
+
+	for _, tt := range []struct {
+		name       string
+		authHeader string
+		wantIDs    []string
+	}{
+		{
+			name:    "public sees free alias instead of upstream name",
+			wantIDs: []string{"deepseek-v4-flash"},
+		},
+		{
+			name:       "authenticated catalog replaces upstream name",
+			authHeader: "Bearer sk-auto0123456789abcdef",
+			wantIDs:    []string{"deepseek-v4-flash", "gpt-5.5"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			listModelsHandler(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("listModelsHandler() status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			var payload struct {
+				Data []ModelInfo `json:"data"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal models response: %v", err)
+			}
+			gotIDs := make([]string, 0, len(payload.Data))
+			for _, model := range payload.Data {
+				gotIDs = append(gotIDs, model.ID)
+			}
+			if !reflect.DeepEqual(gotIDs, tt.wantIDs) {
+				t.Fatalf("listModelsHandler() ids = %#v, want %#v", gotIDs, tt.wantIDs)
+			}
+		})
+	}
+}
+
 func TestExtractUpstreamAuthKeyValidation(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/protocol_regression_test.go
+++ b/protocol_regression_test.go
@@ -14,6 +14,7 @@ func ptr[T any](v T) *T { return &v }
 
 func TestAnthropicRequestConversionPreservesProtocolSemantics(t *testing.T) {
 	zero := 0.0
+	topK := 0
 	tests := []struct {
 		name string
 		in   any
@@ -26,14 +27,14 @@ func TestAnthropicRequestConversionPreservesProtocolSemantics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := ClaudeRequest{Model: "m", MaxTokens: ptr(0), Temperature: &zero, TopP: &zero, ToolChoice: tt.in,
+			req := ClaudeRequest{Model: "m", MaxTokens: ptr(0), Temperature: &zero, TopP: &zero, TopK: &topK, ToolChoice: tt.in,
 				StopSequences: []string{"END"}, Metadata: map[string]any{"user_id": "u-1"}}
 			got := convertClaudeRequest(req)
 			if !reflect.DeepEqual(got.ToolChoice, tt.want) {
 				t.Fatalf("tool choice = %#v, want %#v", got.ToolChoice, tt.want)
 			}
 			body := convertRequest(&got)
-			for key, want := range map[string]any{"max_tokens": 0, "temperature": 0.0, "top_p": 0.0, "stop": []string{"END"}, "user": "u-1"} {
+			for key, want := range map[string]any{"max_tokens": 0, "temperature": 0.0, "top_p": 0.0, "top_k": 0, "stop": []string{"END"}, "user": "u-1"} {
 				if !reflect.DeepEqual(body[key], want) {
 					t.Errorf("%s = %#v, want %#v", key, body[key], want)
 				}
@@ -48,7 +49,7 @@ func TestResponsesNonStreamLengthUsesIncompleteOutcomeEverywhere(t *testing.T) {
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatal(err)
 	}
-	if got["status"] != "incomplete" || got["incomplete_details"].(map[string]any)["reason"] != "max_tokens" {
+	if got["status"] != "incomplete" || got["incomplete_details"].(map[string]any)["reason"] != "max_output_tokens" {
 		t.Fatalf("bad terminal outcome: %s", body)
 	}
 	for _, item := range got["output"].([]any) {
@@ -60,13 +61,14 @@ func TestResponsesNonStreamLengthUsesIncompleteOutcomeEverywhere(t *testing.T) {
 
 func TestResponsesStreamLengthEndsIncompleteAndFunctionDoneHasName(t *testing.T) {
 	upstream := strings.Join([]string{
-		`data: {"id":"r","created":1,"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c","function":{"name":"weather","arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
+		`data: {"id":"r","created":1,"choices":[{"delta":{"reasoning_content":"brief thought"},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{"content":"partial answer","tool_calls":[{"index":0,"id":"c","function":{"name":"weather","arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
 		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Paris\"}"}}]},"finish_reason":"length"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
 		`data: [DONE]`, "",
 	}, "\n")
 	rr := httptest.NewRecorder()
 	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
-	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	responsesStreamHandler(rr, nil, resp, "m", "m", true, nil, nil, ResponsesAPIRequest{})
 	out := rr.Body.String()
 	if !strings.Contains(out, "event: response.incomplete") || strings.Contains(out, "event: response.completed") {
 		t.Fatalf("wrong terminal event:\n%s", out)
@@ -74,8 +76,62 @@ func TestResponsesStreamLengthEndsIncompleteAndFunctionDoneHasName(t *testing.T)
 	if !strings.Contains(out, `"type":"response.function_call_arguments.done"`) || !strings.Contains(out, `"name":"weather"`) {
 		t.Fatalf("function done is incomplete:\n%s", out)
 	}
-	if !strings.Contains(out, `"incomplete_details":{"reason":"max_tokens"}`) {
+	if !strings.Contains(out, `"incomplete_details":{"reason":"max_output_tokens"}`) {
 		t.Fatalf("missing incomplete details:\n%s", out)
+	}
+	doneCount := 0
+	for _, event := range parseSSEEvents(t, out) {
+		if event.Name != "response.output_item.done" {
+			continue
+		}
+		doneCount++
+		item, _ := event.Data["item"].(map[string]any)
+		if item["status"] != "incomplete" {
+			t.Fatalf("done item status = %#v, want incomplete:\n%s", item["status"], out)
+		}
+	}
+	if doneCount != 3 {
+		t.Fatalf("done items = %d, want reasoning, message, and tool:\n%s", doneCount, out)
+	}
+}
+
+func TestAnthropicStreamKeepsParallelToolArgumentDeltasOnTheirOwnBlocks(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"first","arguments":"{\"a\":"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"c1","function":{"name":"second","arguments":"{\"b\":"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}},{"index":1,"function":{"arguments":"2}"}}]},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`, "",
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+
+	var starts, deltas []sseEvent
+	for _, event := range parseSSEEvents(t, rr.Body.String()) {
+		switch event.Name {
+		case "content_block_start":
+			starts = append(starts, event)
+		case "content_block_delta":
+			if delta, _ := event.Data["delta"].(map[string]any); delta["type"] == "input_json_delta" {
+				deltas = append(deltas, event)
+			}
+		}
+	}
+	if len(starts) != 2 {
+		t.Fatalf("tool starts = %d, want 2:\n%s", len(starts), rr.Body.String())
+	}
+	blockByName := map[string]any{}
+	for _, event := range starts {
+		block := event.Data["content_block"].(map[string]any)
+		blockByName[block["name"].(string)] = event.Data["index"]
+	}
+	wantIndices := []any{blockByName["first"], blockByName["second"], blockByName["first"], blockByName["second"]}
+	if len(deltas) != len(wantIndices) {
+		t.Fatalf("argument deltas = %d, want %d:\n%s", len(deltas), len(wantIndices), rr.Body.String())
+	}
+	for i, event := range deltas {
+		if event.Data["index"] != wantIndices[i] {
+			t.Fatalf("delta %d index = %#v, want %#v:\n%s", i, event.Data["index"], wantIndices[i], rr.Body.String())
+		}
 	}
 }
 
@@ -105,20 +161,20 @@ func TestResponsesStreamAllocatesUniqueIndicesWhenToolPrecedesText(t *testing.T)
 
 func TestAnthropicContentPreservesTextImageOrderAndToolErrors(t *testing.T) {
 	msgs := claudeToOpenAIMessages([]ClaudeMessage{{Role: "user", Content: []any{
+		map[string]any{"type": "tool_result", "tool_use_id": "call_1", "is_error": true, "content": "boom"},
 		map[string]any{"type": "text", "text": "before"},
 		map[string]any{"type": "image", "source": map[string]any{"type": "url", "url": "https://example.test/a.png"}},
 		map[string]any{"type": "text", "text": "after"},
-		map[string]any{"type": "tool_result", "tool_use_id": "call_1", "is_error": true, "content": "boom"},
 	}}}, nil)
-	parts, ok := msgs[0].Content.([]any)
+	if got := msgs[0].Content; got != "Error: boom" {
+		t.Fatalf("tool error = %#v", got)
+	}
+	parts, ok := msgs[1].Content.([]any)
 	if !ok || len(parts) != 3 {
 		t.Fatalf("content = %#v", msgs[0].Content)
 	}
 	if parts[0].(map[string]any)["text"] != "before" || parts[1].(map[string]any)["type"] != "image_url" || parts[2].(map[string]any)["text"] != "after" {
 		t.Fatalf("order not preserved: %#v", parts)
-	}
-	if got := msgs[1].Content; got != "Error: boom" {
-		t.Fatalf("tool error = %#v", got)
 	}
 }
 

--- a/protocol_regression_test.go
+++ b/protocol_regression_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestAnthropicRequestConversionPreservesProtocolSemantics(t *testing.T) {
+	zero := 0.0
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"auto", map[string]any{"type": "auto"}, "auto"},
+		{"any", map[string]any{"type": "any"}, "required"},
+		{"named", map[string]any{"type": "tool", "name": "weather"}, map[string]any{"type": "function", "function": map[string]any{"name": "weather"}}},
+		{"none", map[string]any{"type": "none"}, "none"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ClaudeRequest{Model: "m", MaxTokens: ptr(0), Temperature: &zero, TopP: &zero, ToolChoice: tt.in,
+				StopSequences: []string{"END"}, Metadata: map[string]any{"user_id": "u-1"}}
+			got := convertClaudeRequest(req)
+			if !reflect.DeepEqual(got.ToolChoice, tt.want) {
+				t.Fatalf("tool choice = %#v, want %#v", got.ToolChoice, tt.want)
+			}
+			body := convertRequest(&got)
+			for key, want := range map[string]any{"max_tokens": 0, "temperature": 0.0, "top_p": 0.0, "stop": []string{"END"}, "user": "u-1"} {
+				if !reflect.DeepEqual(body[key], want) {
+					t.Errorf("%s = %#v, want %#v", key, body[key], want)
+				}
+			}
+		})
+	}
+}
+
+func TestResponsesNonStreamLengthUsesIncompleteOutcomeEverywhere(t *testing.T) {
+	body := convertChatToResponses([]byte(`{"id":"r","created":1,"choices":[{"finish_reason":"length","message":{"content":"partial","tool_calls":[{"id":"c","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`), "m", false, nil, nil)
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["status"] != "incomplete" || got["incomplete_details"].(map[string]any)["reason"] != "max_tokens" {
+		t.Fatalf("bad terminal outcome: %s", body)
+	}
+	for _, item := range got["output"].([]any) {
+		if item.(map[string]any)["status"] != "incomplete" {
+			t.Fatalf("item completed during truncation: %s", body)
+		}
+	}
+}
+
+func TestResponsesStreamLengthEndsIncompleteAndFunctionDoneHasName(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c","function":{"name":"weather","arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Paris\"}"}}]},"finish_reason":"length"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+		`data: [DONE]`, "",
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	out := rr.Body.String()
+	if !strings.Contains(out, "event: response.incomplete") || strings.Contains(out, "event: response.completed") {
+		t.Fatalf("wrong terminal event:\n%s", out)
+	}
+	if !strings.Contains(out, `"type":"response.function_call_arguments.done"`) || !strings.Contains(out, `"name":"weather"`) {
+		t.Fatalf("function done is incomplete:\n%s", out)
+	}
+	if !strings.Contains(out, `"incomplete_details":{"reason":"max_tokens"}`) {
+		t.Fatalf("missing incomplete details:\n%s", out)
+	}
+}
+
+func TestResponsesStreamAllocatesUniqueIndicesWhenToolPrecedesText(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","choices":[{"delta":{"tool_calls":[{"index":0,"id":"c","function":{"name":"f","arguments":"{}"}}]}}]}`,
+		`data: {"choices":[{"delta":{"content":"answer"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`, "",
+	}, "\n")
+	rr := httptest.NewRecorder()
+	responsesStreamHandler(rr, nil, &http.Response{Body: io.NopCloser(strings.NewReader(upstream))}, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	var added []map[string]any
+	for _, block := range strings.Split(rr.Body.String(), "\n\n") {
+		if !strings.HasPrefix(block, "event: response.output_item.added") {
+			continue
+		}
+		var event map[string]any
+		lines := strings.Split(block, "\n")
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(lines[1], "data: ")), &event); err == nil {
+			added = append(added, event)
+		}
+	}
+	if len(added) != 2 || added[0]["output_index"] == added[1]["output_index"] {
+		t.Fatalf("indices are not unique: %#v\n%s", added, rr.Body.String())
+	}
+}
+
+func TestAnthropicContentPreservesTextImageOrderAndToolErrors(t *testing.T) {
+	msgs := claudeToOpenAIMessages([]ClaudeMessage{{Role: "user", Content: []any{
+		map[string]any{"type": "text", "text": "before"},
+		map[string]any{"type": "image", "source": map[string]any{"type": "url", "url": "https://example.test/a.png"}},
+		map[string]any{"type": "text", "text": "after"},
+		map[string]any{"type": "tool_result", "tool_use_id": "call_1", "is_error": true, "content": "boom"},
+	}}}, nil)
+	parts, ok := msgs[0].Content.([]any)
+	if !ok || len(parts) != 3 {
+		t.Fatalf("content = %#v", msgs[0].Content)
+	}
+	if parts[0].(map[string]any)["text"] != "before" || parts[1].(map[string]any)["type"] != "image_url" || parts[2].(map[string]any)["text"] != "after" {
+		t.Fatalf("order not preserved: %#v", parts)
+	}
+	if got := msgs[1].Content; got != "Error: boom" {
+		t.Fatalf("tool error = %#v", got)
+	}
+}
+
+func TestJSONSchemaCleaningReturnsCopyAndPreservesConstraints(t *testing.T) {
+	original := map[string]any{"type": "object", "additionalProperties": false, "properties": map[string]any{"when": map[string]any{"type": "string", "format": "date-time", "title": "When"}}}
+	before, _ := json.Marshal(original)
+	clean := cleanJsonSchema(original).(map[string]any)
+	after, _ := json.Marshal(original)
+	if string(before) != string(after) {
+		t.Fatalf("input mutated: before=%s after=%s", before, after)
+	}
+	if clean["additionalProperties"] != false {
+		t.Fatalf("constraint removed: %#v", clean)
+	}
+	when := clean["properties"].(map[string]any)["when"].(map[string]any)
+	if when["format"] != "date-time" {
+		t.Fatalf("format removed: %#v", when)
+	}
+}
+
+func TestChatUsageOnlyChunkIsForwardedWithFullUsage(t *testing.T) {
+	line := `data: {"id":"x","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5,"completion_tokens_details":{"reasoning_tokens":2}}}`
+	got, usage := convertStreamChunkWithUsage(line, true)
+	if got == "" {
+		t.Fatal("usage-only chunk was dropped")
+	}
+	if usage["completion_tokens_details"].(map[string]any)["reasoning_tokens"] != float64(2) {
+		t.Fatalf("usage details lost: %#v", usage)
+	}
+}
+
+func TestChatResponsePreservesUsageDetailsAndSystemFingerprint(t *testing.T) {
+	in := []byte(`{"id":"x","system_fingerprint":"fp_1","choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5,"prompt_tokens_details":{"cached_tokens":1},"completion_tokens_details":{"reasoning_tokens":2}}}`)
+	out, err := convertResponse(in, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["system_fingerprint"] != "fp_1" {
+		t.Fatalf("fingerprint lost: %s", out)
+	}
+	if got["usage"].(map[string]any)["completion_tokens_details"] == nil {
+		t.Fatalf("usage details lost: %s", out)
+	}
+}

--- a/responses_protocol.go
+++ b/responses_protocol.go
@@ -1,0 +1,49 @@
+package main
+
+// responseOutcome is shared by streaming and non-streaming builders so their
+// top-level and item statuses cannot drift apart.
+type responseOutcome struct {
+	Status            string
+	Event             string
+	IncompleteDetails any
+}
+
+func responsesOutcome(finishReason string) responseOutcome {
+	if finishReason == "length" {
+		return responseOutcome{Status: "incomplete", Event: "response.incomplete", IncompleteDetails: map[string]any{"reason": "max_tokens"}}
+	}
+	return responseOutcome{Status: "completed", Event: "response.completed"}
+}
+
+// outputIndexAllocator assigns indices by first appearance. It deliberately
+// does not derive one item's index from whether another item happened to exist.
+type outputIndexAllocator struct{ next int }
+
+func (a *outputIndexAllocator) Allocate() int {
+	index := a.next
+	a.next++
+	return index
+}
+
+func (a *outputIndexAllocator) Len() int { return a.next }
+
+func applyResponsesRequestEcho(response map[string]any, req ResponsesAPIRequest) {
+	if req.Metadata != nil {
+		response["metadata"] = cloneJSONValue(req.Metadata)
+	}
+	if req.Reasoning.Effort != "" {
+		response["reasoning"] = map[string]any{"effort": req.Reasoning.Effort}
+	}
+	if req.ParallelToolCalls != nil {
+		response["parallel_tool_calls"] = *req.ParallelToolCalls
+	}
+	if req.Temperature != nil {
+		response["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		response["top_p"] = *req.TopP
+	}
+	if req.MaxTokens != nil {
+		response["max_output_tokens"] = *req.MaxTokens
+	}
+}

--- a/responses_protocol.go
+++ b/responses_protocol.go
@@ -10,7 +10,7 @@ type responseOutcome struct {
 
 func responsesOutcome(finishReason string) responseOutcome {
 	if finishReason == "length" {
-		return responseOutcome{Status: "incomplete", Event: "response.incomplete", IncompleteDetails: map[string]any{"reason": "max_tokens"}}
+		return responseOutcome{Status: "incomplete", Event: "response.incomplete", IncompleteDetails: map[string]any{"reason": "max_output_tokens"}}
 	}
 	return responseOutcome{Status: "completed", Event: "response.completed"}
 }
@@ -45,5 +45,8 @@ func applyResponsesRequestEcho(response map[string]any, req ResponsesAPIRequest)
 	}
 	if req.MaxTokens != nil {
 		response["max_output_tokens"] = *req.MaxTokens
+	}
+	if req.Store != nil {
+		response["store"] = *req.Store
 	}
 }

--- a/responses_store_test.go
+++ b/responses_store_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResponsesStoreFalseDoesNotMakeStateAvailableToPreviousResponseID(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			responseID := fmt.Sprintf("resp_not_stored_%t", stream)
+			firstBody := fmt.Sprintf(`{"id":%q,"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"weather","arguments":"{}"}}]},"finish_reason":"stop"}]}
+data: [DONE]
+`, responseID)
+			if stream {
+				firstBody = "data: " + firstBody
+			} else {
+				firstBody = fmt.Sprintf(`{"id":%q,"choices":[{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"weather","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`, responseID)
+			}
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{
+				{status: http.StatusOK, body: firstBody},
+				{status: http.StatusOK, body: `{"id":"resp_next","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`},
+			})
+
+			firstReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(fmt.Sprintf(`{
+				"model":"primary-model",
+				"input":"call a tool",
+				"stream":%t,
+				"store":false,
+				"tools":[{"type":"function","name":"weather","parameters":{"type":"object"}}]
+			}`, stream)))
+			responsesHandler(httptest.NewRecorder(), firstReq)
+
+			secondReq := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(fmt.Sprintf(`{
+				"model":"primary-model",
+				"previous_response_id":%q,
+				"input":"continue"
+			}`, responseID)))
+			secondRec := httptest.NewRecorder()
+			responsesHandler(secondRec, secondReq)
+			if secondRec.Code != http.StatusOK {
+				t.Fatalf("second status = %d, body=%s", secondRec.Code, secondRec.Body.String())
+			}
+
+			payload := transport.requestPayloads[1]
+			if _, ok := payload["tools"]; ok {
+				t.Fatalf("tools leaked from store:false response: %#v", payload["tools"])
+			}
+			messages, _ := payload["messages"].([]any)
+			if len(messages) != 1 {
+				encoded, _ := json.Marshal(messages)
+				t.Fatalf("previous output replayed after store:false: %s", encoded)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 修改说明

这次 PR 整理了两项修改：

### 1. 提升 API 协议兼容性

- 完善 Chat Completions、Responses API 与 Anthropic Messages 的请求和响应转换。
- 保留显式零值、usage details、system fingerprint 和 JSON Schema 约束；多模态顺序保证限定为 text/image 子序列及 Anthropic 合法的 tool_result-first 顺序。
- 统一 finish/stop reason、usage 和 Responses 完成/截断状态。
- 修复流式 Responses 的 output index、函数调用完成事件及 `response.incomplete` 终态。
- 增加协议回归测试，并更新 API 支持范围文档。

### 2. 优化模型别名展示

- 默认配置增加常用免费模型别名。
- `/v1/models` 在权限过滤完成后，用客户端别名替换对应的上游模型 ID。
- 避免同时暴露别名和真实 ID，并保持目录去重和稳定顺序。
- Docker 默认配置与配置文档同步更新。

## 验证

- `make fmt`
- `make test`
- `make vet`
- `make build`
- `git diff --check origin/main...HEAD`