### PR TITLE
fix: protocol compatibility and public free-model routing

### DIFF
--- a/anthropic_decode_test.go
+++ b/anthropic_decode_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -359,7 +360,7 @@ func TestCallOpenCodeAPI_AnthropicErrorReturns502(t *testing.T) {
 		status: http.StatusOK,
 		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
 	}})
-	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	body, status, _, err := callOpenCodeAPI(context.Background(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
 	if err == nil {
 		t.Fatal("callOpenCodeAPI should return error for native Anthropic error body")
 	}
@@ -376,7 +377,7 @@ func TestCallOpenCodeAPI_AnthropicTruncatedReturns502(t *testing.T) {
 		status: http.StatusOK,
 		body:   `{"type":"message_start","message":{"id":"msg_t","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
 	}})
-	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	body, status, _, err := callOpenCodeAPI(context.Background(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
 	if err == nil {
 		t.Fatal("callOpenCodeAPI should return error for truncated Anthropic SSE")
 	}
@@ -1163,7 +1164,7 @@ func TestCallOpenCodeAPI_AnthropicMalformedReturns502(t *testing.T) {
 		status: http.StatusOK,
 		body:   strings.Join([]string{`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`, `{bad json}`}, "\n"),
 	}})
-	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	body, status, _, err := callOpenCodeAPI(context.Background(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
 	if err == nil {
 		t.Fatal("should return error for malformed Anthropic SSE")
 	}
@@ -1191,7 +1192,7 @@ func TestClaudeStream_UsageMergeMultipleChunks(t *testing.T) {
 		``,
 	}, "\n")
 	rr := httptest.NewRecorder()
-	claudeStreamHandler(t.Context(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
 	events := parseSSEEvents(t, rr.Body.String())
 	var usage map[string]any
 	for _, event := range events {
@@ -1611,7 +1612,7 @@ func TestCallOpenCodeAPI_AnthropicError502_ClaudeShape(t *testing.T) {
 		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
 	}})
 	// Test the error shape from callOpenCodeAPI directly
-	_, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	_, status, _, err := callOpenCodeAPI(context.Background(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/anthropic_decode_test.go
+++ b/anthropic_decode_test.go
@@ -1,0 +1,2653 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// =====================================================================
+// Test 1: Native JSON blocks [text, tool_use, text, thinking] -> content
+// order and signature, tool_calls association ID
+// =====================================================================
+
+func TestAnthropicNativeJSON_BlocksOrderAndToolID(t *testing.T) {
+	body := `{
+		"id":"msg_abc",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-test",
+		"stop_reason":"end_turn",
+		"content":[
+			{"type":"text","text":"Hello "},
+			{"type":"tool_use","id":"toolu_01ABC","name":"get_weather","input":{"city":"SF"}},
+			{"type":"text","text":" Done."},
+			{"type":"thinking","thinking":"Let me think","signature":"sig123"}
+		],
+		"usage":{"input_tokens":10,"output_tokens":20}
+	}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "claude-test")
+	if err != nil {
+		t.Fatalf("convertAnthropicToOpenAI error: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	choices, _ := resp["choices"].([]any)
+	if len(choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(choices))
+	}
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	// Content should be "Hello  Done." (text blocks concatenated in order)
+	content, _ := msg["content"].(string)
+	if content != "Hello  Done." {
+		t.Fatalf("content = %q, want %q", content, "Hello  Done.")
+	}
+
+	// reasoning_content should have the thinking text
+	rc, _ := msg["reasoning_content"].(string)
+	if rc != "Let me think" {
+		t.Fatalf("reasoning_content = %q, want %q", rc, "Let me think")
+	}
+
+	// tool_calls should preserve the original ID
+	toolCalls, _ := msg["tool_calls"].([]any)
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call, got %d", len(toolCalls))
+	}
+	tc, _ := toolCalls[0].(map[string]any)
+	id, _ := tc["id"].(string)
+	if id != "toolu_01ABC" {
+		t.Fatalf("tool_call id = %q, want toolu_01ABC", id)
+	}
+	fn, _ := tc["function"].(map[string]any)
+	name, _ := fn["name"].(string)
+	if name != "get_weather" {
+		t.Fatalf("tool name = %q, want get_weather", name)
+	}
+	args, _ := fn["arguments"].(string)
+	if !strings.Contains(args, "SF") {
+		t.Fatalf("tool arguments = %q, want to contain SF", args)
+	}
+
+	// Private field should preserve original ordered blocks
+	private, _ := msg["_opencode2api_anthropic_content"].([]any)
+	if len(private) != 4 {
+		t.Fatalf("expected 4 private blocks, got %d", len(private))
+	}
+	pb0, _ := private[0].(map[string]any)
+	pb1, _ := private[1].(map[string]any)
+	pb2, _ := private[2].(map[string]any)
+	pb3, _ := private[3].(map[string]any)
+	if pb0["type"] != "text" || pb1["type"] != "tool_use" ||
+		pb2["type"] != "text" || pb3["type"] != "thinking" {
+		t.Fatalf("private block order wrong: %v", private)
+	}
+	// Signature should be preserved in private thinking block
+	sig, _ := pb3["signature"].(string)
+	if sig != "sig123" {
+		t.Fatalf("signature = %q, want sig123", sig)
+	}
+}
+
+// =====================================================================
+// Test 2: SSE interleaved index/order, thinking+signature, tool partial input
+// =====================================================================
+
+func TestAnthropicSSE_InterleavedIndexOrder(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_s1","type":"message","role":"assistant","model":"claude-test","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"Let me think"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"sig456"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_02","name":"search","input":{}}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\"hello\"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":5,"output_tokens":15}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "claude-test")
+	if err != nil {
+		t.Fatalf("convertAnthropicToOpenAI error: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	// Text should be "Hello world" (index 0 deltas concatenated, interleaving with other blocks is fine)
+	content, _ := msg["content"].(string)
+	if content != "Hello world" {
+		t.Fatalf("content = %q, want 'Hello world'", content)
+	}
+
+	// Thinking + signature
+	rc, _ := msg["reasoning_content"].(string)
+	if rc != "Let me think" {
+		t.Fatalf("reasoning_content = %q, want 'Let me think'", rc)
+	}
+
+	// Tool call
+	toolCalls, _ := msg["tool_calls"].([]any)
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call, got %d", len(toolCalls))
+	}
+	tc, _ := toolCalls[0].(map[string]any)
+	id, _ := tc["id"].(string)
+	if id != "toolu_02" {
+		t.Fatalf("tool id = %q, want toolu_02", id)
+	}
+	fn, _ := tc["function"].(map[string]any)
+	args, _ := fn["arguments"].(string)
+	if !strings.Contains(args, "hello") {
+		t.Fatalf("tool args = %q, want to contain 'hello'", args)
+	}
+
+	// Private blocks should preserve order: text(0), thinking(1), tool_use(2)
+	private, _ := msg["_opencode2api_anthropic_content"].([]any)
+	if len(private) != 3 {
+		t.Fatalf("expected 3 private blocks, got %d", len(private))
+	}
+	pb0, _ := private[0].(map[string]any)
+	pb1, _ := private[1].(map[string]any)
+	pb2, _ := private[2].(map[string]any)
+	if pb0["type"] != "text" || pb1["type"] != "thinking" || pb2["type"] != "tool_use" {
+		t.Fatalf("private block order wrong: %v", private)
+	}
+	sig, _ := pb1["signature"].(string)
+	if sig != "sig456" {
+		t.Fatalf("signature = %q, want sig456", sig)
+	}
+}
+
+// =====================================================================
+// Test 3: message_start input/cache usage + message_delta output usage merge
+// (top-level usage)
+// =====================================================================
+
+func TestAnthropicSSE_UsageMerge(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_u","type":"message","role":"assistant","model":"claude-test","stop_reason":null,"usage":{"input_tokens":100,"cache_creation_input_tokens":8,"cache_read_input_tokens":64,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":100,"output_tokens":35,"cache_creation_input_tokens":8,"cache_read_input_tokens":64}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "claude-test")
+	if err != nil {
+		t.Fatalf("convertAnthropicToOpenAI error: %v", err)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	usage, ok := resp["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("usage missing: %#v", resp["usage"])
+	}
+	// Chat usage: prompt_tokens from input_tokens, completion_tokens from output_tokens
+	pt, _ := usage["prompt_tokens"].(float64)
+	if int(pt) != 100 {
+		t.Fatalf("prompt_tokens = %v, want 100", pt)
+	}
+	ct, _ := usage["completion_tokens"].(float64)
+	if int(ct) != 35 {
+		t.Fatalf("completion_tokens = %v, want 35", ct)
+	}
+	tt, _ := usage["total_tokens"].(float64)
+	if int(tt) != 135 {
+		t.Fatalf("total_tokens = %v, want 135", tt)
+	}
+	// Cache detail should be preserved
+	cc, _ := usage["cache_creation_input_tokens"].(float64)
+	if int(cc) != 8 {
+		t.Fatalf("cache_creation_input_tokens = %v, want 8", cc)
+	}
+	cr, _ := usage["cache_read_input_tokens"].(float64)
+	if int(cr) != 64 {
+		t.Fatalf("cache_read_input_tokens = %v, want 64", cr)
+	}
+}
+
+// Test 3b: usage merge does not lose fields — message_start has input,
+// message_delta has only output (missing input). Must not zero input.
+func TestAnthropicSSE_UsageMergeNoFieldLoss(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_u2","type":"message","role":"assistant","model":"claude-test","stop_reason":null,"usage":{"input_tokens":120,"cache_read_input_tokens":32,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":40}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "claude-test")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	usage, _ := resp["usage"].(map[string]any)
+	pt, _ := usage["prompt_tokens"].(float64)
+	if int(pt) != 120 {
+		t.Fatalf("prompt_tokens = %v, want 120 (must survive merge)", pt)
+	}
+	ct, _ := usage["completion_tokens"].(float64)
+	if int(ct) != 40 {
+		t.Fatalf("completion_tokens = %v, want 40", ct)
+	}
+	cr, _ := usage["cache_read_input_tokens"].(float64)
+	if int(cr) != 32 {
+		t.Fatalf("cache_read_input_tokens = %v, want 32 (must survive merge)", cr)
+	}
+}
+
+// =====================================================================
+// Test 4: SSE error preserves type/message, missing message_stop, malformed
+// event JSON, malformed tool input JSON all return errors
+// =====================================================================
+
+func TestAnthropicSSE_ErrorEvent(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_e1","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"error","error":{"type":"overloaded_error","message":"Internal server error"}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for SSE error event")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Fatalf("error should mention error type, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Internal server error") {
+		t.Fatalf("error should mention error message, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_MissingMessageStop(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_e2","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for missing message_stop")
+	}
+	if !strings.Contains(err.Error(), "message_stop") {
+		t.Fatalf("error should mention message_stop, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_MalformedEventJSON(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_e3","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{bad json}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for malformed event JSON")
+	}
+}
+
+func TestAnthropicSSE_MalformedToolInputJSON(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_e4","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_x","name":"fn","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{bad}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for malformed tool input JSON")
+	}
+}
+
+// =====================================================================
+// Test 5: callOpenCodeAPI returns non-200 (502) for native Anthropic
+// error/truncation — using the conversion interface directly
+// =====================================================================
+
+func TestConvertAnthropicToOpenAI_NativeErrorReturnsError(t *testing.T) {
+	// Native error JSON body
+	body := `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for native Anthropic error body")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Fatalf("error should contain error type, got: %v", err)
+	}
+}
+
+func TestConvertAnthropicToOpenAI_TruncatedSSEReturnsError(t *testing.T) {
+	// Truncated SSE — no message_stop
+	sse := `{"type":"message_start","message":{"id":"msg_t","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for truncated SSE (no message_stop)")
+	}
+}
+
+func TestCallOpenCodeAPI_AnthropicErrorReturns502(t *testing.T) {
+	// Upstream returns 200 with a native Anthropic error body.
+	// callOpenCodeAPI should convert this to a 502 error.
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+	}})
+	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err == nil {
+		t.Fatal("callOpenCodeAPI should return error for native Anthropic error body")
+	}
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", status)
+	}
+	if body != nil {
+		t.Fatalf("body should be nil on error, got %s", string(body))
+	}
+}
+
+func TestCallOpenCodeAPI_AnthropicTruncatedReturns502(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"message_start","message":{"id":"msg_t","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+	}})
+	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err == nil {
+		t.Fatal("callOpenCodeAPI should return error for truncated Anthropic SSE")
+	}
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", status)
+	}
+	if body != nil {
+		t.Fatalf("body should be nil on error, got %s", string(body))
+	}
+}
+
+// Test 5b: convertResponse strips the private field
+func TestConvertResponse_StripsPrivateAnthropicField(t *testing.T) {
+	body := `{"id":"msg_p","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello","_opencode2api_anthropic_content":[{"type":"text","text":"Hello"}]},"finish_reason":"stop"}]}`
+	out, err := convertResponse([]byte(body), false)
+	if err != nil {
+		t.Fatalf("convertResponse error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	if _, exists := msg["_opencode2api_anthropic_content"]; exists {
+		t.Fatalf("private field should be stripped by convertResponse")
+	}
+}
+
+// Test 5c: pure text (no thinking/tool) returns string content (compatibility)
+func TestAnthropicNativeJSON_PureTextReturnsString(t *testing.T) {
+	body := `{"id":"msg_pt","type":"message","role":"assistant","model":"claude-test","stop_reason":"end_turn","content":[{"type":"text","text":"Hello world"}],"usage":{"input_tokens":5,"output_tokens":3}}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "claude-test")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	content, _ := msg["content"].(string)
+	if content != "Hello world" {
+		t.Fatalf("content = %q, want 'Hello world'", content)
+	}
+	// Should NOT have private field for pure text
+	if _, exists := msg["_opencode2api_anthropic_content"]; exists {
+		t.Fatalf("pure text should not have private field")
+	}
+	if _, exists := msg["reasoning_content"]; exists {
+		t.Fatalf("pure text should not have reasoning_content")
+	}
+	if _, exists := msg["tool_calls"]; exists {
+		t.Fatalf("pure text should not have tool_calls")
+	}
+}
+
+// Test: SSE with data: prefix lines should work
+func TestAnthropicSSE_DataPrefix(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_d","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	content, _ := msg["content"].(string)
+	if content != "Hi" {
+		t.Fatalf("content = %q, want 'Hi'", content)
+	}
+}
+
+// Test: unknown event types are ignored
+func TestAnthropicSSE_UnknownEventIgnored(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_u","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+		`{"type":"some_unknown_event","foo":"bar"}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("unknown event should be ignored, got error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	if len(choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(choices))
+	}
+}
+
+// Test: tool_use missing ID gets generated ID matching protocol
+func TestAnthropicSSE_ToolUseMissingIDGeneratesToolu(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_mid","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"fn","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call, got %d", len(toolCalls))
+	}
+	tc, _ := toolCalls[0].(map[string]any)
+	id, _ := tc["id"].(string)
+	if !strings.HasPrefix(id, "toolu_") {
+		t.Fatalf("generated ID should start with toolu_, got %q", id)
+	}
+}
+
+// Test: usage merge preserves cached-token details from message_start
+func TestAnthropicSSE_UsageMergePreservesCachedTokens(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_ct","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":200,"cache_creation_input_tokens":10,"cache_read_input_tokens":50,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":30}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	usage, _ := resp["usage"].(map[string]any)
+	cc, _ := usage["cache_creation_input_tokens"].(float64)
+	if int(cc) != 10 {
+		t.Fatalf("cache_creation_input_tokens = %v, want 10", cc)
+	}
+	cr, _ := usage["cache_read_input_tokens"].(float64)
+	if int(cr) != 50 {
+		t.Fatalf("cache_read_input_tokens = %v, want 50", cr)
+	}
+	tt, _ := usage["total_tokens"].(float64)
+	if int(tt) != 230 {
+		t.Fatalf("total_tokens = %v, want 230", tt)
+	}
+}
+
+// Test: convertResponse also strips private field with keepReasoning=true
+func TestConvertResponse_StripsPrivateFieldKeepReasoning(t *testing.T) {
+	body := `{"id":"msg_p2","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hi","reasoning_content":"thinking","_opencode2api_anthropic_content":[{"type":"thinking","thinking":"thinking"}]},"finish_reason":"stop"}]}`
+	out, err := convertResponse([]byte(body), true)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	if _, exists := msg["_opencode2api_anthropic_content"]; exists {
+		t.Fatalf("private field should be stripped even with keepReasoning=true")
+	}
+	// reasoning_content should be kept when keepReasoning=true
+	if _, exists := msg["reasoning_content"]; !exists {
+		t.Fatalf("reasoning_content should be kept with keepReasoning=true")
+	}
+}
+
+// Test: convertChatToResponses does not leak private field
+func TestConvertChatToResponses_NoPrivateFieldLeak(t *testing.T) {
+	chatBody := `{"id":"chatcmpl_x","created":1234,"choices":[{"index":0,"message":{"role":"assistant","content":"Hi","_opencode2api_anthropic_content":[{"type":"text","text":"Hi"}]},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	out := convertChatToResponses([]byte(chatBody), "m", false, nil, nil)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	outStr := string(out)
+	if strings.Contains(outStr, "_opencode2api_anthropic_content") {
+		t.Fatalf("Responses conversion leaks private field:\n%s", outStr)
+	}
+}
+
+// Test: parseAnthropicSSE with data: prefix lines
+func TestParseAnthropicSSE_DataPrefixCompatibility(t *testing.T) {
+	sse := `data: {"type":"message_start","message":{"id":"msg_dp","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+data: {"type":"content_block_stop","index":0}
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+data: {"type":"message_stop"}`
+	msg, blocks, err := parseAnthropicSSE([]byte(sse))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("message should not be nil")
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0]["type"] != "text" {
+		t.Fatalf("block type = %v, want text", blocks[0]["type"])
+	}
+}
+
+// Test: native JSON message with multiple tool_use blocks
+func TestAnthropicNativeJSON_MultipleToolUse(t *testing.T) {
+	body := `{
+		"id":"msg_mt",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-test",
+		"stop_reason":"tool_use",
+		"content":[
+			{"type":"text","text":"Let me search"},
+			{"type":"tool_use","id":"toolu_a","name":"search","input":{"q":"test"}},
+			{"type":"tool_use","id":"toolu_b","name":"fetch","input":{"url":"http://x"}}
+		],
+		"usage":{"input_tokens":10,"output_tokens":20}
+	}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "claude-test")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	if len(toolCalls) != 2 {
+		t.Fatalf("expected 2 tool_calls, got %d", len(toolCalls))
+	}
+	tc0, _ := toolCalls[0].(map[string]any)
+	if tc0["id"] != "toolu_a" {
+		t.Fatalf("first tool id = %v, want toolu_a", tc0["id"])
+	}
+	tc1, _ := toolCalls[1].(map[string]any)
+	if tc1["id"] != "toolu_b" {
+		t.Fatalf("second tool id = %v, want toolu_b", tc1["id"])
+	}
+	fr, _ := choice["finish_reason"].(string)
+	if fr != "tool_calls" {
+		t.Fatalf("finish_reason = %q, want tool_calls", fr)
+	}
+}
+
+// Test: isAnthropicFormat detects SSE with data: prefix
+func TestIsAnthropicFormat_SSEWithPrefix(t *testing.T) {
+	sse := `data: {"type":"message_start","message":{}}`
+	if !isAnthropicFormat([]byte(sse)) {
+		t.Fatal("isAnthropicFormat should detect SSE with data: prefix")
+	}
+}
+
+// Test: convertAnthropicMessageToOpenAI returns error on nil msg
+func TestConvertAnthropicMessageToOpenAI_NilMsg(t *testing.T) {
+	_, err := convertAnthropicMessageToOpenAI(nil, "m")
+	if err == nil {
+		t.Fatal("expected error for nil message")
+	}
+}
+
+// Test: buildOpenAIResponse returns error on nil msg
+func TestBuildOpenAIResponse_NilMsg(t *testing.T) {
+	_, err := buildOpenAIResponse(nil, nil, "m")
+	if err == nil {
+		t.Fatal("expected error for nil message")
+	}
+}
+
+// Test: convertAnthropicToOpenAI does not silently return body on parse failure
+func TestConvertAnthropicToOpenAI_NoSilentPassthrough(t *testing.T) {
+	// Random non-JSON, non-SSE garbage
+	_, err := convertAnthropicToOpenAI([]byte("garbage not json"), "m")
+	if err == nil {
+		t.Fatal("should not silently return garbage body as success")
+	}
+}
+
+// =====================================================================
+// Fix 1: mergeUsageMaps — src overrides dst including 0
+// =====================================================================
+
+func TestMergeUsageMaps_SrcOverridesIncludingZero(t *testing.T) {
+	dst := map[string]any{"output_tokens": float64(1), "input_tokens": float64(10)}
+	src := map[string]any{"output_tokens": float64(35)}
+	result := mergeUsageMaps(dst, src)
+	ot, _ := result["output_tokens"].(float64)
+	if int(ot) != 35 {
+		t.Fatalf("output_tokens = %v, want 35 (src must override even non-zero)", ot)
+	}
+	it, _ := result["input_tokens"].(float64)
+	if int(it) != 10 {
+		t.Fatalf("input_tokens = %v, want 10 (absent from src must be retained)", it)
+	}
+}
+
+func TestMergeUsageMaps_ZeroOverridesNonZero(t *testing.T) {
+	dst := map[string]any{"output_tokens": float64(35)}
+	src := map[string]any{"output_tokens": float64(0)}
+	result := mergeUsageMaps(dst, src)
+	ot, _ := result["output_tokens"].(float64)
+	if int(ot) != 0 {
+		t.Fatalf("output_tokens = %v, want 0 (src zero must override)", ot)
+	}
+}
+
+func TestAnthropicSSE_UsageMerge_OutputTokensOverwrite(t *testing.T) {
+	// message_start has output_tokens=1, message_delta has output_tokens=35.
+	// Final must be 35.
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_ot","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":100,"output_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":100,"output_tokens":35}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	usage, _ := resp["usage"].(map[string]any)
+	ct, _ := usage["completion_tokens"].(float64)
+	if int(ct) != 35 {
+		t.Fatalf("completion_tokens = %v, want 35 (message_delta must override message_start)", ct)
+	}
+}
+
+func TestMergeUsageMaps_NestedMapRecursive(t *testing.T) {
+	dst := map[string]any{
+		"prompt_tokens_details": map[string]any{"cached_tokens": float64(32)},
+	}
+	src := map[string]any{
+		"prompt_tokens_details": map[string]any{"cached_tokens": float64(64)},
+	}
+	result := mergeUsageMaps(dst, src)
+	ptd, _ := result["prompt_tokens_details"].(map[string]any)
+	ct, _ := ptd["cached_tokens"].(float64)
+	if int(ct) != 64 {
+		t.Fatalf("nested cached_tokens = %v, want 64", ct)
+	}
+}
+
+// =====================================================================
+// Fix 2: parseAnthropicSSE — block start/stop tracking, sorted by index,
+// SSE metadata lines, duplicate start error, unclosed block error
+// =====================================================================
+
+func TestAnthropicSSE_OutOfOrderStartSortedByIndex(t *testing.T) {
+	// Starts arrive in order 2, 0, 1. Output must be sorted 0, 1, 2.
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_oo","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"third"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"first"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"second"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	// Text blocks concatenated in index order: first second third
+	content, _ := msg["content"].(string)
+	if content != "firstsecondthird" {
+		t.Fatalf("content = %q, want 'firstsecondthird'", content)
+	}
+}
+
+func TestAnthropicSSE_DuplicateStartError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_ds","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for duplicate content_block_start")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error should mention duplicate, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_DeltaForUnknownIndexError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_du","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_delta","index":5,"delta":{"type":"text_delta","text":"Hi"}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for delta on unknown index")
+	}
+	if !strings.Contains(err.Error(), "unknown index") {
+		t.Fatalf("error should mention unknown index, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_StopForUnknownIndexError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_su","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_stop","index":3}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for stop on unknown index")
+	}
+}
+
+func TestAnthropicSSE_UnclosedBlockError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_ub","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		// Missing content_block_stop for index 0
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for unclosed block")
+	}
+	if !strings.Contains(err.Error(), "unclosed") {
+		t.Fatalf("error should mention unclosed, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_StandardSSEMetadataLines(t *testing.T) {
+	// Standard SSE format with event:/data:/comment lines.
+	sse := strings.Join([]string{
+		`: keepalive comment`,
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_sse","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("standard SSE should parse, got error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	content, _ := msg["content"].(string)
+	if content != "Hi" {
+		t.Fatalf("content = %q, want 'Hi'", content)
+	}
+}
+
+func TestAnthropicSSE_ToolUseStartWithNonEmptyInput(t *testing.T) {
+	// content_block_start with a complete input (no partial_json).
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_ti","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_99","name":"fn","input":{"x":42}}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	if len(toolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call, got %d", len(toolCalls))
+	}
+	tc, _ := toolCalls[0].(map[string]any)
+	fn, _ := tc["function"].(map[string]any)
+	args, _ := fn["arguments"].(string)
+	if !strings.Contains(args, "42") {
+		t.Fatalf("args = %q, want to contain 42", args)
+	}
+}
+
+// =====================================================================
+// Fix 3: buildOpenAIResponse — generated ID in both private block and tool_calls,
+// private field for redacted_thinking
+// =====================================================================
+
+func TestBuildOpenAIResponse_GeneratedIDInPrivateAndToolCalls(t *testing.T) {
+	// tool_use block with no ID — generated ID must appear in both
+	// _opencode2api_anthropic_content and tool_calls.
+	blocks := []map[string]any{
+		{"type": "tool_use", "name": "fn", "input": map[string]any{"x": 1}},
+	}
+	out, err := buildOpenAIResponse(map[string]any{
+		"id":          "msg_g",
+		"stop_reason": "tool_use",
+		"usage":       map[string]any{"input_tokens": float64(1), "output_tokens": float64(1)},
+	}, blocks, "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	tcID, _ := tc["id"].(string)
+
+	private, _ := msg["_opencode2api_anthropic_content"].([]any)
+	pb, _ := private[0].(map[string]any)
+	pbID, _ := pb["id"].(string)
+
+	if tcID != pbID {
+		t.Fatalf("tool_calls ID %q != private block ID %q", tcID, pbID)
+	}
+	if !strings.HasPrefix(tcID, "toolu_") {
+		t.Fatalf("generated ID should start with toolu_, got %q", tcID)
+	}
+}
+
+func TestBuildOpenAIResponse_PrivateFieldForRedactedThinking(t *testing.T) {
+	blocks := []map[string]any{
+		{"type": "text", "text": "Hello"},
+		{"type": "redacted_thinking", "data": "redacted_data"},
+	}
+	out2, err2 := buildOpenAIResponse(map[string]any{
+		"id":          "msg_r2",
+		"stop_reason": "end_turn",
+	}, blocks, "m")
+	if err2 != nil {
+		t.Fatalf("error: %v", err2)
+	}
+	var resp map[string]any
+	json.Unmarshal(out2, &resp)
+	_ = out2
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	private, ok := msg["_opencode2api_anthropic_content"].([]any)
+	if !ok {
+		t.Fatal("private field should exist for redacted_thinking")
+	}
+	if len(private) != 2 {
+		t.Fatalf("expected 2 private blocks, got %d", len(private))
+	}
+	pb1, _ := private[1].(map[string]any)
+	if pb1["type"] != "redacted_thinking" {
+		t.Fatalf("second block type = %v, want redacted_thinking", pb1["type"])
+	}
+	data, _ := pb1["data"].(string)
+	if data != "redacted_data" {
+		t.Fatalf("data = %q, want redacted_data", data)
+	}
+}
+
+// =====================================================================
+// Fix 4: openAIToClaudeResponse — private blocks, signature, ID rules
+// =====================================================================
+
+func TestOpenAIToClaudeResponse_PrivateBlocksOrdered(t *testing.T) {
+	// Chat response with private Anthropic blocks.
+	chatBody := `{
+		"id":"chatcmpl_x",
+		"object":"chat.completion",
+		"model":"m",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":"Hello Done.",
+				"reasoning_content":"Let me think",
+				"tool_calls":[{"id":"toolu_01","type":"function","function":{"name":"fn","arguments":"{\"x\":1}"}}],
+				"_opencode2api_anthropic_content":[
+					{"type":"text","text":"Hello "},
+					{"type":"thinking","thinking":"Let me think","signature":"sig_abc"},
+					{"type":"tool_use","id":"toolu_01","name":"fn","input":{"x":1}},
+					{"type":"text","text":"Done."}
+				]
+			},
+			"finish_reason":"stop"
+		}],
+		"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+	}`
+	out := openAIToClaudeResponse([]byte(chatBody), "m", true)
+	var resp ClaudeResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Must preserve order: text, thinking, tool_use, text
+	if len(resp.Content) != 4 {
+		t.Fatalf("expected 4 content blocks, got %d", len(resp.Content))
+	}
+	if resp.Content[0].Type != "text" || resp.Content[0].Text != "Hello " {
+		t.Fatalf("block 0 = %#v, want text 'Hello '", resp.Content[0])
+	}
+	if resp.Content[1].Type != "thinking" || resp.Content[1].Thinking != "Let me think" {
+		t.Fatalf("block 1 = %#v, want thinking", resp.Content[1])
+	}
+	if resp.Content[1].Signature != "sig_abc" {
+		t.Fatalf("signature = %q, want sig_abc", resp.Content[1].Signature)
+	}
+	if resp.Content[2].Type != "tool_use" || resp.Content[2].ID != "toolu_01" {
+		t.Fatalf("block 2 = %#v, want tool_use toolu_01", resp.Content[2])
+	}
+	if resp.Content[3].Type != "text" || resp.Content[3].Text != "Done." {
+		t.Fatalf("block 3 = %#v, want text 'Done.'", resp.Content[3])
+	}
+}
+
+func TestOpenAIToClaudeResponse_WantReasoningFalseFiltersThinking(t *testing.T) {
+	chatBody := `{
+		"id":"chatcmpl_y",
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":"Hi",
+				"_opencode2api_anthropic_content":[
+					{"type":"thinking","thinking":"secret","signature":"sig"},
+					{"type":"text","text":"Hi"},
+					{"type":"tool_use","id":"toolu_02","name":"fn","input":{}}
+				]
+			},
+			"finish_reason":"stop"
+		}]
+	}`
+	out := openAIToClaudeResponse([]byte(chatBody), "m", false)
+	var resp ClaudeResponse
+	json.Unmarshal(out, &resp)
+	// thinking filtered, text and tool_use kept
+	for _, c := range resp.Content {
+		if c.Type == "thinking" || c.Type == "redacted_thinking" {
+			t.Fatalf("thinking should be filtered when wantReasoning=false: %#v", c)
+		}
+	}
+	hasText := false
+	hasTool := false
+	for _, c := range resp.Content {
+		if c.Type == "text" {
+			hasText = true
+		}
+		if c.Type == "tool_use" && c.ID == "toolu_02" {
+			hasTool = true
+		}
+	}
+	if !hasText {
+		t.Fatal("text block should be preserved")
+	}
+	if !hasTool {
+		t.Fatal("tool_use block should be preserved with original ID")
+	}
+}
+
+func TestOpenAIToClaudeResponse_IDRules(t *testing.T) {
+	// Valid msg_ ID preserved
+	chatBody1 := `{"id":"msg_abc123","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}`
+	out1 := openAIToClaudeResponse([]byte(chatBody1), "m", false)
+	var resp1 ClaudeResponse
+	json.Unmarshal(out1, &resp1)
+	if resp1.ID != "msg_abc123" {
+		t.Fatalf("valid msg_ ID should be preserved, got %q", resp1.ID)
+	}
+
+	// Invalid ID (chatcmpl_) must not be leaked
+	chatBody2 := `{"id":"chatcmpl_xyz","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}`
+	out2 := openAIToClaudeResponse([]byte(chatBody2), "m", false)
+	var resp2 ClaudeResponse
+	json.Unmarshal(out2, &resp2)
+	if !strings.HasPrefix(resp2.ID, "msg_") {
+		t.Fatalf("invalid ID should be replaced with msg_, got %q", resp2.ID)
+	}
+	if strings.Contains(resp2.ID, "chatcmpl") {
+		t.Fatalf("chatcmpl ID must not leak, got %q", resp2.ID)
+	}
+
+	// resp_ ID must not leak
+	chatBody3 := `{"id":"resp_abc","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}`
+	out3 := openAIToClaudeResponse([]byte(chatBody3), "m", false)
+	var resp3 ClaudeResponse
+	json.Unmarshal(out3, &resp3)
+	if !strings.HasPrefix(resp3.ID, "msg_") {
+		t.Fatalf("resp_ ID should be replaced with msg_, got %q", resp3.ID)
+	}
+}
+
+func TestOpenAIToClaudeResponse_FallbackStringContent(t *testing.T) {
+	// No private field — fallback to string content + reasoning + tool_calls
+	chatBody := `{"id":"chatcmpl_z","choices":[{"message":{"role":"assistant","content":"Hello","reasoning_content":"thinking step","tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`
+	out := openAIToClaudeResponse([]byte(chatBody), "m", true)
+	var resp ClaudeResponse
+	json.Unmarshal(out, &resp)
+	hasThinking := false
+	hasText := false
+	hasTool := false
+	for _, c := range resp.Content {
+		if c.Type == "thinking" {
+			hasThinking = true
+		}
+		if c.Type == "text" && c.Text == "Hello" {
+			hasText = true
+		}
+		if c.Type == "tool_use" && c.ID == "call_1" {
+			hasTool = true
+		}
+	}
+	if !hasText {
+		t.Fatal("fallback should preserve text content")
+	}
+	if !hasTool {
+		t.Fatal("fallback should preserve tool call ID")
+	}
+	// wantReasoning=true so thinking should be present
+	if !hasThinking {
+		t.Fatal("fallback should include thinking when wantReasoning=true")
+	}
+}
+
+func TestOpenAIToClaudeResponse_NoFabricatedSignature(t *testing.T) {
+	// thinking block without signature — must not fabricate one
+	chatBody := `{"id":"msg_nosig","choices":[{"message":{"role":"assistant","content":"Hi","_opencode2api_anthropic_content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"Hi"}]},"finish_reason":"stop"}]}`
+	out := openAIToClaudeResponse([]byte(chatBody), "m", true)
+	var resp ClaudeResponse
+	json.Unmarshal(out, &resp)
+	for _, c := range resp.Content {
+		if c.Type == "thinking" && c.Signature != "" {
+			t.Fatalf("signature should be empty, got %q", c.Signature)
+		}
+	}
+}
+
+// =====================================================================
+// Fix 5: callOpenCodeAPI error propagation (already tested, add malformed)
+// =====================================================================
+
+func TestCallOpenCodeAPI_AnthropicMalformedReturns502(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   strings.Join([]string{`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`, `{bad json}`}, "\n"),
+	}})
+	body, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err == nil {
+		t.Fatal("should return error for malformed Anthropic SSE")
+	}
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", status)
+	}
+	if body != nil {
+		t.Fatalf("body should be nil, got %s", string(body))
+	}
+}
+
+// =====================================================================
+// Fix 6: Claude stream usage merge — multiple usage chunks
+// =====================================================================
+
+func TestClaudeStream_UsageMergeMultipleChunks(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}],"usage":{"prompt_tokens":50,"completion_tokens":0}}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":20}}`,
+		``,
+		`data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":35,"prompt_tokens_details":{"cached_tokens":64}}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(t.Context(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	var usage map[string]any
+	for _, event := range events {
+		if event.Name != "message_delta" {
+			continue
+		}
+		u, ok := event.Data["usage"].(map[string]any)
+		if !ok {
+			t.Fatalf("message_delta usage missing: %#v", event.Data["usage"])
+		}
+		usage = u
+	}
+	if usage == nil {
+		t.Fatalf("message_delta not found: %s", rr.Body.String())
+	}
+	pt, _ := usage["input_tokens"].(float64)
+	if int(pt) != 100 {
+		t.Fatalf("input_tokens = %v, want 100 (merged from multiple chunks)", pt)
+	}
+	ct, _ := usage["output_tokens"].(float64)
+	if int(ct) != 35 {
+		t.Fatalf("output_tokens = %v, want 35 (merged from multiple chunks)", ct)
+	}
+	// cached_tokens should survive merge
+	if _, ok := usage["cache_read_input_tokens"]; !ok {
+		t.Fatalf("cache_read_input_tokens should be present from prompt_tokens_details.cached_tokens")
+	}
+	cr, _ := usage["cache_read_input_tokens"].(float64)
+	if int(cr) != 64 {
+		t.Fatalf("cache_read_input_tokens = %v, want 64", cr)
+	}
+}
+
+// =====================================================================
+// Fix 1: redacted_thinking uses data field, not signature
+// =====================================================================
+
+func TestAnthropicNativeJSON_RedactedThinkingDataField(t *testing.T) {
+	body := `{
+		"id":"msg_rt",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-test",
+		"stop_reason":"end_turn",
+		"content":[
+			{"type":"text","text":"Hello"},
+			{"type":"redacted_thinking","data":"redacted_secret_data"}
+		],
+		"usage":{"input_tokens":10,"output_tokens":20}
+	}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "claude-test")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	// Private blocks should have redacted_thinking with data
+	private, _ := msg["_opencode2api_anthropic_content"].([]any)
+	if len(private) != 2 {
+		t.Fatalf("expected 2 private blocks, got %d", len(private))
+	}
+	pb1, _ := private[1].(map[string]any)
+	if pb1["type"] != "redacted_thinking" {
+		t.Fatalf("type = %v, want redacted_thinking", pb1["type"])
+	}
+	data, _ := pb1["data"].(string)
+	if data != "redacted_secret_data" {
+		t.Fatalf("data = %q, want redacted_secret_data", data)
+	}
+	// Must NOT have signature
+	if _, exists := pb1["signature"]; exists {
+		t.Fatal("redacted_thinking must not have signature field")
+	}
+}
+
+func TestAnthropicSSE_RedactedThinkingDataField(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"msg_rt2","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"redacted_sse_data"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	private, _ := msg["_opencode2api_anthropic_content"].([]any)
+	if len(private) != 2 {
+		t.Fatalf("expected 2 private blocks, got %d", len(private))
+	}
+	pb0, _ := private[0].(map[string]any)
+	if pb0["type"] != "redacted_thinking" {
+		t.Fatalf("type = %v, want redacted_thinking", pb0["type"])
+	}
+	data, _ := pb0["data"].(string)
+	if data != "redacted_sse_data" {
+		t.Fatalf("data = %q, want redacted_sse_data", data)
+	}
+	if _, exists := pb0["signature"]; exists {
+		t.Fatal("redacted_thinking must not have signature")
+	}
+}
+
+func TestOpenAIToClaudeResponse_RedactedThinkingDataPassthrough(t *testing.T) {
+	chatBody := `{
+		"id":"msg_rt3",
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"content":"Hi",
+				"_opencode2api_anthropic_content":[
+					{"type":"redacted_thinking","data":"secret_data"},
+					{"type":"text","text":"Hi"}
+				]
+			},
+			"finish_reason":"stop"
+		}]
+	}`
+	out := openAIToClaudeResponse([]byte(chatBody), "m", true)
+	var resp ClaudeResponse
+	json.Unmarshal(out, &resp)
+	found := false
+	for _, c := range resp.Content {
+		if c.Type == "redacted_thinking" {
+			found = true
+			if c.Data != "secret_data" {
+				t.Fatalf("data = %q, want secret_data", c.Data)
+			}
+			if c.Signature != "" {
+				t.Fatalf("signature should be empty, got %q", c.Signature)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("redacted_thinking block not found in response: %#v", resp.Content)
+	}
+}
+
+// =====================================================================
+// Fix 2: parser completeness
+// =====================================================================
+
+func TestAnthropicSSE_MissingMessageStart(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for missing message_start")
+	}
+	if !strings.Contains(err.Error(), "message_start") {
+		t.Fatalf("error should mention message_start, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_MultipleMessageStartError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"message_start","message":{"id":"m2","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for multiple message_start")
+	}
+	if !strings.Contains(err.Error(), "multiple") {
+		t.Fatalf("error should mention multiple, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_DeltaAfterStopError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"late"}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for delta after stop")
+	}
+	if !strings.Contains(err.Error(), "already-stopped") {
+		t.Fatalf("error should mention already-stopped, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_DuplicateStopError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_stop","index":0}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for duplicate content_block_stop")
+	}
+}
+
+func TestAnthropicSSE_MissingStopReasonError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for missing stop_reason")
+	}
+	if !strings.Contains(err.Error(), "stop_reason") {
+		t.Fatalf("error should mention stop_reason, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_MissingIndexError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for missing index")
+	}
+	if !strings.Contains(err.Error(), "index") {
+		t.Fatalf("error should mention index, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_NegativeIndexError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":-1,"content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for negative index")
+	}
+}
+
+func TestAnthropicNativeJSON_MissingContentArrayError(t *testing.T) {
+	body := `{"id":"msg_nc","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for missing content array")
+	}
+	if !strings.Contains(err.Error(), "content") {
+		t.Fatalf("error should mention content, got: %v", err)
+	}
+}
+
+func TestAnthropicNativeJSON_MissingStopReasonError(t *testing.T) {
+	body := `{"id":"msg_nsr","type":"message","role":"assistant","model":"m","content":[{"type":"text","text":"Hi"}],"usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for missing stop_reason")
+	}
+}
+
+// =====================================================================
+// Fix 3: response ID normalization
+// =====================================================================
+
+func TestNormalizeChatResponseID(t *testing.T) {
+	// Already valid chatcmpl- ID preserved
+	id := normalizeChatResponseID("chatcmpl-abc123")
+	if id != "chatcmpl-abc123" {
+		t.Fatalf("got %q, want chatcmpl-abc123", id)
+	}
+	// Non-chatcmpl ID gets fresh chatcmpl- ID (must not leak msg_)
+	id = normalizeChatResponseID("msg_abc")
+	if !strings.HasPrefix(id, "chatcmpl-") {
+		t.Fatalf("got %q, want chatcmpl- prefix", id)
+	}
+	if strings.Contains(id, "msg_abc") {
+		t.Fatalf("got %q, must not contain original non-chatcmpl ID", id)
+	}
+	// Empty ID generates
+	id = normalizeChatResponseID("")
+	if !strings.HasPrefix(id, "chatcmpl-") {
+		t.Fatalf("got %q, want chatcmpl- prefix", id)
+	}
+}
+
+func TestNormalizeResponsesID(t *testing.T) {
+	// Already valid resp_ ID preserved
+	id := normalizeResponsesID("resp_abc123")
+	if id != "resp_abc123" {
+		t.Fatalf("got %q, want resp_abc123", id)
+	}
+	// Non-resp_ ID gets fresh resp_ ID (must not leak chatcmpl)
+	id = normalizeResponsesID("chatcmpl_xyz")
+	if !strings.HasPrefix(id, "resp_") {
+		t.Fatalf("got %q, want resp_ prefix", id)
+	}
+	if strings.Contains(id, "chatcmpl") {
+		t.Fatalf("got %q, must not contain chatcmpl", id)
+	}
+	// Empty ID generates
+	id = normalizeResponsesID("")
+	if !strings.HasPrefix(id, "resp_") {
+		t.Fatalf("got %q, want resp_ prefix", id)
+	}
+}
+
+func TestNormalizeClaudeMessageID(t *testing.T) {
+	// Valid msg_ preserved
+	id := normalizeClaudeMessageID("msg_abc123")
+	if id != "msg_abc123" {
+		t.Fatalf("got %q, want msg_abc123", id)
+	}
+	// chatcmpl_ replaced
+	id = normalizeClaudeMessageID("chatcmpl_xyz")
+	if !strings.HasPrefix(id, "msg_") || strings.Contains(id, "chatcmpl") {
+		t.Fatalf("got %q, want msg_ prefix without chatcmpl", id)
+	}
+	// resp_ replaced
+	id = normalizeClaudeMessageID("resp_abc")
+	if !strings.HasPrefix(id, "msg_") || strings.Contains(id, "resp_") {
+		t.Fatalf("got %q, want msg_ prefix without resp", id)
+	}
+	// Empty generates
+	id = normalizeClaudeMessageID("")
+	if !strings.HasPrefix(id, "msg_") {
+		t.Fatalf("got %q, want msg_ prefix", id)
+	}
+}
+
+func TestConvertResponse_NormalizesChatID(t *testing.T) {
+	body := `{"id":"msg_xyz","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}`
+	out, _ := convertResponse([]byte(body), false)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	id, _ := resp["id"].(string)
+	if !strings.HasPrefix(id, "chatcmpl-") {
+		t.Fatalf("id = %q, want chatcmpl- prefix", id)
+	}
+}
+
+func TestConvertResponse_PreservesValidChatID(t *testing.T) {
+	body := `{"id":"chatcmpl-abc","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}`
+	out, _ := convertResponse([]byte(body), false)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	id, _ := resp["id"].(string)
+	if id != "chatcmpl-abc" {
+		t.Fatalf("id = %q, want chatcmpl-abc", id)
+	}
+}
+
+func TestConvertChatToResponses_NormalizesResponsesID(t *testing.T) {
+	chatBody := `{"id":"chatcmpl_xyz","created":1234,"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	out := convertChatToResponses([]byte(chatBody), "m", false, nil, nil)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	id, _ := resp["id"].(string)
+	if !strings.HasPrefix(id, "resp_") {
+		t.Fatalf("id = %q, want resp_ prefix", id)
+	}
+	// Must not leak chatcmpl
+	if strings.Contains(id, "chatcmpl") {
+		t.Fatalf("id = %q, must not contain chatcmpl", id)
+	}
+}
+
+func TestConvertChatToResponses_PreservesValidResponsesID(t *testing.T) {
+	chatBody := `{"id":"resp_abc","created":1234,"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	out := convertChatToResponses([]byte(chatBody), "m", false, nil, nil)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	id, _ := resp["id"].(string)
+	if id != "resp_abc" {
+		t.Fatalf("id = %q, want resp_abc", id)
+	}
+}
+
+func TestConvertResponse_DoesNotModifyToolCallID(t *testing.T) {
+	body := `{"id":"chatcmpl_x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hi","tool_calls":[{"id":"toolu_abc","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`
+	out, _ := convertResponse([]byte(body), false)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	id, _ := tc["id"].(string)
+	if id != "toolu_abc" {
+		t.Fatalf("tool call ID = %q, want toolu_abc (must not be modified)", id)
+	}
+}
+
+// =====================================================================
+// Fix 4: protocol conversion error propagation
+// =====================================================================
+
+func TestCallOpenCodeAPI_AnthropicError502_ClaudeShape(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+	}})
+	// Test the error shape from callOpenCodeAPI directly
+	_, status, _, err := callOpenCodeAPI(t.Context(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", status)
+	}
+	var ape *anthropicProtocolError
+	if !errors.As(err, &ape) {
+		t.Fatalf("error should be anthropicProtocolError, got %T: %v", err, err)
+	}
+	if ape.errType != "overloaded_error" {
+		t.Fatalf("errType = %q, want overloaded_error", ape.errType)
+	}
+	if ape.message != "Server overloaded" {
+		t.Fatalf("message = %q, want 'Server overloaded'", ape.message)
+	}
+}
+
+func TestWriteProtocolConvError_ClaudeShape(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeUpstreamError(rr, http.StatusBadGateway,
+		&anthropicProtocolError{errType: "overloaded_error", message: "Server overloaded"}, "claude")
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rr.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	if body["type"] != "error" {
+		t.Fatalf("type = %v, want error", body["type"])
+	}
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+func TestWriteProtocolConvError_ChatShape(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeUpstreamError(rr, http.StatusBadGateway,
+		&anthropicProtocolError{errType: "overloaded_error", message: "Server overloaded"}, "chat")
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rr.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+func TestWriteProtocolConvError_ResponsesShape(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeUpstreamError(rr, http.StatusBadGateway,
+		&anthropicProtocolError{errType: "overloaded_error", message: "Server overloaded"}, "responses")
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rr.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+func TestClaudeHandler_AnthropicError502_VisibleTypeMessage(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["type"] != "error" {
+		t.Fatalf("type = %v, want error", body["type"])
+	}
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+// =====================================================================
+// Fix 1: deterministicResponseID — same input produces same output
+// =====================================================================
+
+func TestDeterministicResponseID_SameInputSameOutput(t *testing.T) {
+	id1 := deterministicResponseID("chatcmpl-", "msg_abc")
+	id2 := deterministicResponseID("chatcmpl-", "msg_abc")
+	if id1 != id2 {
+		t.Fatalf("same input must produce same output: %q vs %q", id1, id2)
+	}
+	if !strings.HasPrefix(id1, "chatcmpl-") {
+		t.Fatalf("must have chatcmpl- prefix: %q", id1)
+	}
+}
+
+func TestDeterministicResponseID_ValidPreserved(t *testing.T) {
+	id := deterministicResponseID("chatcmpl-", "chatcmpl-abc123")
+	if id != "chatcmpl-abc123" {
+		t.Fatalf("valid ID should be preserved: got %q", id)
+	}
+	id = deterministicResponseID("resp_", "resp_xyz789")
+	if id != "resp_xyz789" {
+		t.Fatalf("valid ID should be preserved: got %q", id)
+	}
+}
+
+func TestDeterministicResponseID_DifferentInputsDifferentOutputs(t *testing.T) {
+	id1 := deterministicResponseID("chatcmpl-", "msg_abc")
+	id2 := deterministicResponseID("chatcmpl-", "msg_def")
+	if id1 == id2 {
+		t.Fatalf("different inputs must produce different outputs: %q", id1)
+	}
+}
+
+func TestNormalizeChatResponseID_Deterministic(t *testing.T) {
+	id1 := normalizeChatResponseID("msg_abc")
+	id2 := normalizeChatResponseID("msg_abc")
+	if id1 != id2 {
+		t.Fatalf("same non-chatcmpl ID must map deterministically: %q vs %q", id1, id2)
+	}
+	if !strings.HasPrefix(id1, "chatcmpl-") {
+		t.Fatalf("must have chatcmpl- prefix: %q", id1)
+	}
+}
+
+// Test: Chat stream same upstream ID across chunks produces same chatcmpl ID
+func TestConvertStreamChunkWithUsage_DeterministicID(t *testing.T) {
+	// Two chunks with same upstream ID should produce same normalized ID
+	line1 := `data: {"id":"msg_xyz","choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}`
+	line2 := `data: {"id":"msg_xyz","choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}`
+
+	out1, _ := convertStreamChunkWithUsage(line1, false)
+	out2, _ := convertStreamChunkWithUsage(line2, false)
+
+	var chunk1, chunk2 map[string]any
+	json.Unmarshal([]byte(out1[6:]), &chunk1)
+	json.Unmarshal([]byte(out2[6:]), &chunk2)
+
+	id1, _ := chunk1["id"].(string)
+	id2, _ := chunk2["id"].(string)
+
+	if id1 != id2 {
+		t.Fatalf("same upstream ID must produce same chatcmpl ID: %q vs %q", id1, id2)
+	}
+	if !strings.HasPrefix(id1, "chatcmpl-") {
+		t.Fatalf("must have chatcmpl- prefix: %q", id1)
+	}
+}
+
+// Test: Responses top-level ID and derived msg_/rs_ IDs are consistent
+func TestConvertChatToResponses_DerivedIDsConsistent(t *testing.T) {
+	chatBody := `{"id":"msg_test123","created":1234,"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	out := convertChatToResponses([]byte(chatBody), "m", false, nil, nil)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+
+	topID, _ := resp["id"].(string)
+	if !strings.HasPrefix(topID, "resp_") {
+		t.Fatalf("top-level ID must have resp_ prefix: %q", topID)
+	}
+
+	output, _ := resp["output"].([]any)
+	for _, item := range output {
+		blk, _ := item.(map[string]any)
+		itemID, _ := blk["id"].(string)
+		if strings.HasPrefix(itemID, "msg_") {
+			if !strings.Contains(itemID, topID) {
+				t.Fatalf("msg_ derived ID %q must contain normalized top ID %q", itemID, topID)
+			}
+		}
+		if strings.HasPrefix(itemID, "rs_") {
+			if !strings.Contains(itemID, topID) {
+				t.Fatalf("rs_ derived ID %q must contain normalized top ID %q", itemID, topID)
+			}
+		}
+	}
+}
+
+// =====================================================================
+// Fix 2: responsesStreamHandler normalizeResponsesID
+// =====================================================================
+
+func TestResponsesStream_NormalizesUpstreamID(t *testing.T) {
+	// Upstream sends a chatcmpl_ ID; responsesStreamHandler should normalize to resp_
+	upstream := strings.Join([]string{
+		`data: {"id":"chatcmpl_xyz","created":1234,"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_xyz","choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	for _, e := range events {
+		if e.Name == "response.created" {
+			r, _ := e.Data["response"].(map[string]any)
+			id, _ := r["id"].(string)
+			if !strings.HasPrefix(id, "resp_") {
+				t.Fatalf("response.created ID should have resp_ prefix, got %q", id)
+			}
+			if strings.Contains(id, "chatcmpl") {
+				t.Fatalf("response.created ID must not contain chatcmpl: %q", id)
+			}
+		}
+	}
+}
+
+// =====================================================================
+// Fix 3: extractBlockIndex strict type checking
+// =====================================================================
+
+func TestExtractBlockIndex_IntegerAccepted(t *testing.T) {
+	idx, ok := extractBlockIndex(map[string]any{"index": float64(5)})
+	if !ok || idx != 5 {
+		t.Fatalf("integer 5 should be accepted: idx=%d ok=%v", idx, ok)
+	}
+}
+
+func TestExtractBlockIndex_FloatRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": float64(2.5)})
+	if ok {
+		t.Fatal("float 2.5 should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_StringRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": "5"})
+	if ok {
+		t.Fatal("string \"5\" should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_BoolRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": true})
+	if ok {
+		t.Fatal("bool should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_NegativeRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": float64(-1)})
+	if ok {
+		t.Fatal("negative should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_MissingRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{})
+	if ok {
+		t.Fatal("missing index should be rejected")
+	}
+}
+
+// =====================================================================
+// Fix 4: message_stop timing and event ordering
+// =====================================================================
+
+func TestAnthropicSSE_EventAfterStopError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for event after message_stop")
+	}
+	if !strings.Contains(err.Error(), "after message_stop") {
+		t.Fatalf("error should mention 'after message_stop', got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_ContentBeforeMessageStartError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for content before message_start")
+	}
+}
+
+func TestAnthropicSSE_MessageDeltaBeforeMessageStartError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for message_delta before message_start")
+	}
+}
+
+func TestAnthropicSSE_MessageStopValidatesStopReason(t *testing.T) {
+	// message_stop with stop_reason still null should error
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for message_stop without stop_reason")
+	}
+	if !strings.Contains(err.Error(), "stop_reason") {
+		t.Fatalf("error should mention stop_reason, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_MessageStopValidatesBlocksStopped(t *testing.T) {
+	// message_stop with unclosed block should error at stop time
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for unclosed block at message_stop")
+	}
+	if !strings.Contains(err.Error(), "unclosed") {
+		t.Fatalf("error should mention unclosed, got: %v", err)
+	}
+}
+
+// =====================================================================
+// Fix 5: native JSON content validation
+// =====================================================================
+
+func TestAnthropicNativeJSON_NonObjectContentBlockError(t *testing.T) {
+	body := `{"id":"msg_no","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","content":["not an object"],"usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for non-object content block")
+	}
+	if !strings.Contains(err.Error(), "non-object") {
+		t.Fatalf("error should mention non-object, got: %v", err)
+	}
+}
+
+func TestAnthropicNativeJSON_ToolUseEmptyNameError(t *testing.T) {
+	body := `{"id":"msg_en","type":"message","role":"assistant","model":"m","stop_reason":"tool_use","content":[{"type":"tool_use","id":"toolu_x","name":"","input":{}}],"usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for tool_use with empty name")
+	}
+}
+
+func TestAnthropicNativeJSON_ToolUseIDPreserved(t *testing.T) {
+	body := `{"id":"msg_tid","type":"message","role":"assistant","model":"m","stop_reason":"tool_use","content":[{"type":"tool_use","id":"toolu_preserve","name":"fn","input":{"x":1}}],"usage":{}}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	if tc["id"] != "toolu_preserve" {
+		t.Fatalf("tool ID = %v, want toolu_preserve", tc["id"])
+	}
+}
+
+func TestAnthropicSSE_ContentBlockStartMissingTypeError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for content_block_start without type")
+	}
+}
+
+func TestAnthropicSSE_ContentBlockStartUnsupportedTypeError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"unsupported_type"}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for unsupported content_block type")
+	}
+}
+
+func TestAnthropicSSE_ToolUseStartEmptyNameError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_x","name":"","input":{}}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for tool_use with empty name in SSE")
+	}
+}
+
+// =====================================================================
+// Fix 6: typed error with errors.As
+// =====================================================================
+
+func TestAnthropicProtocolError_ErrorsAs(t *testing.T) {
+	orig := &anthropicProtocolError{errType: "overloaded_error", message: "Server overloaded"}
+	var ape *anthropicProtocolError
+	if !errors.As(orig, &ape) {
+		t.Fatal("errors.As should extract anthropicProtocolError")
+	}
+	if ape.errType != "overloaded_error" {
+		t.Fatalf("errType = %q", ape.errType)
+	}
+	if ape.message != "Server overloaded" {
+		t.Fatalf("message = %q", ape.message)
+	}
+}
+
+func TestWriteUpstreamError_NonTypedDefaultType(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeUpstreamError(rr, http.StatusBadGateway, fmt.Errorf("some random transport error"), "chat")
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rr.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	// Non-typed errors get generic upstream_error, not upstream_protocol_error
+	if errObj["type"] != "upstream_error" {
+		t.Fatalf("type = %v, want upstream_error", errObj["type"])
+	}
+	if errObj["message"] != "upstream error" {
+		t.Fatalf("message = %v, want 'upstream error'", errObj["message"])
+	}
+	// Must not expose err.Error() string
+	if msg, _ := errObj["message"].(string); strings.Contains(msg, "transport") {
+		t.Fatalf("message must not expose transport error details: %q", msg)
+	}
+}
+
+// =====================================================================
+// Fix 6: Integration tests — Chat/Claude/Responses each
+// =====================================================================
+
+func TestChatHandler_AnthropicError502(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	chatCompletionsHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+func TestResponsesHandler_AnthropicError502(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"primary-model","input":[]}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "overloaded_error" {
+		t.Fatalf("error.type = %v, want overloaded_error", errObj["type"])
+	}
+	if errObj["message"] != "Server overloaded" {
+		t.Fatalf("error.message = %v, want 'Server overloaded'", errObj["message"])
+	}
+}
+
+// Test: malformed (non-typed) conversion error gets upstream_protocol_error type
+func TestClaudeHandler_MalformedAnthropicReturns502(t *testing.T) {
+	// Truncated SSE (no message_stop) — not an anthropicProtocolError
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body: strings.Join([]string{
+			`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{}}}`,
+		}, "\n"),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	// Non-typed conversion error gets generic upstream_error
+	if errObj["type"] != "upstream_error" {
+		t.Fatalf("error.type = %v, want upstream_error", errObj["type"])
+	}
+	if errObj["message"] != "upstream error" {
+		t.Fatalf("error.message = %v, want 'upstream error'", errObj["message"])
+	}
+}
+
+// =====================================================================
+// Fix 1: convertChatToResponses empty ID still consistent
+// =====================================================================
+
+func TestConvertChatToResponses_EmptyIDConsistent(t *testing.T) {
+	chatBody := `{"id":"","created":1234,"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	out := convertChatToResponses([]byte(chatBody), "m", false, nil, nil)
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	topID, _ := resp["id"].(string)
+	if !strings.HasPrefix(topID, "resp_") {
+		t.Fatalf("empty ID should still get resp_ prefix: %q", topID)
+	}
+	output, _ := resp["output"].([]any)
+	for _, item := range output {
+		blk, _ := item.(map[string]any)
+		itemID, _ := blk["id"].(string)
+		if strings.HasPrefix(itemID, "msg_") || strings.HasPrefix(itemID, "rs_") {
+			if !strings.Contains(itemID, topID) {
+				t.Fatalf("derived ID %q must contain top ID %q", itemID, topID)
+			}
+		}
+	}
+}
+
+// =====================================================================
+// Fix 2: extractBlockIndex NaN/Inf/range
+// =====================================================================
+
+func TestExtractBlockIndex_NaNRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": math.NaN()})
+	if ok {
+		t.Fatal("NaN should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_InfRejected(t *testing.T) {
+	_, ok := extractBlockIndex(map[string]any{"index": math.Inf(1)})
+	if ok {
+		t.Fatal("+Inf should be rejected")
+	}
+	_, ok = extractBlockIndex(map[string]any{"index": math.Inf(-1)})
+	if ok {
+		t.Fatal("-Inf should be rejected")
+	}
+}
+
+func TestExtractBlockIndex_LargeNumberRejected(t *testing.T) {
+	// Value larger than max int (2^63)
+	_, ok := extractBlockIndex(map[string]any{"index": float64(9223372036854775808.0)})
+	if ok {
+		t.Fatal("value exceeding int range should be rejected")
+	}
+}
+
+// =====================================================================
+// Fix 3: ping after message_stop allowed
+// =====================================================================
+
+func TestAnthropicSSE_PingAfterStopAllowed(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+		`{"type":"ping"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("ping after message_stop should be allowed, got error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	if len(choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(choices))
+	}
+}
+
+func TestAnthropicSSE_DataEventAfterStopError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("content_block_start after message_stop should error")
+	}
+}
+
+// =====================================================================
+// Fix 4: message_start missing message object error
+// =====================================================================
+
+func TestAnthropicSSE_MessageStartMissingMessageError(t *testing.T) {
+	sse := `{"type":"message_start"}`
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for message_start without message object")
+	}
+	if !strings.Contains(err.Error(), "message object") {
+		t.Fatalf("error should mention message object, got: %v", err)
+	}
+}
+
+func TestAnthropicSSE_ContentBlockDeltaMissingDeltaError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for content_block_delta without delta")
+	}
+}
+
+func TestAnthropicSSE_ContentBlockDeltaMissingDeltaTypeError(t *testing.T) {
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"text":"Hi"}}`,
+	}, "\n")
+	_, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err == nil {
+		t.Fatal("expected error for content_block_delta without delta type")
+	}
+}
+
+// =====================================================================
+// Fix 5: unknown block type in native JSON preserves private, not leaked
+// =====================================================================
+
+func TestAnthropicNativeJSON_UnknownBlockPreservesPrivate(t *testing.T) {
+	body := `{"id":"msg_uk","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","content":[{"type":"text","text":"Hello"},{"type":"custom_block","data":"custom"}],"usage":{"input_tokens":1,"output_tokens":1}}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+
+	// Private field should exist (unknown block sets hasNonText)
+	private, ok := msg["_opencode2api_anthropic_content"].([]any)
+	if !ok {
+		t.Fatal("private field should exist for unknown block type")
+	}
+	if len(private) != 2 {
+		t.Fatalf("expected 2 private blocks, got %d", len(private))
+	}
+	pb1, _ := private[1].(map[string]any)
+	if pb1["type"] != "custom_block" {
+		t.Fatalf("private block type = %v, want custom_block", pb1["type"])
+	}
+
+	// convertResponse should strip private field
+	out2, _ := convertResponse(out, false)
+	var resp2 map[string]any
+	json.Unmarshal(out2, &resp2)
+	choices2, _ := resp2["choices"].([]any)
+	choice2, _ := choices2[0].(map[string]any)
+	msg2, _ := choice2["message"].(map[string]any)
+	if _, exists := msg2["_opencode2api_anthropic_content"]; exists {
+		t.Fatal("private field should be stripped by convertResponse")
+	}
+}
+
+// =====================================================================
+// Fix 6: tool initial input vs partial delta not concatenated
+// =====================================================================
+
+func TestAnthropicSSE_ToolUseInitialInputNotConcatenatedWithDelta(t *testing.T) {
+	// content_block_start has input:{"x":42}, then input_json_delta provides {"y":1}
+	// The result should use ONLY the delta ({"y":1}), not concatenated ({"x":42}{"y":1})
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_x","name":"fn","input":{"x":42}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"y\":1}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	fn, _ := tc["function"].(map[string]any)
+	args, _ := fn["arguments"].(string)
+
+	// Should parse as valid JSON with y:1, NOT x:42
+	var input map[string]any
+	if err := json.Unmarshal([]byte(args), &input); err != nil {
+		t.Fatalf("args should be valid JSON, got %q: %v", args, err)
+	}
+	if _, exists := input["y"]; !exists {
+		t.Fatalf("args should contain y from delta, got %q", args)
+	}
+	if _, exists := input["x"]; exists {
+		t.Fatalf("args should NOT contain x from initial input when deltas present, got %q", args)
+	}
+}
+
+func TestAnthropicSSE_ToolUseInitialInputOnly(t *testing.T) {
+	// content_block_start has input:{"x":42}, no input_json_delta
+	// Result should use initial input {"x":42}
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_y","name":"fn","input":{"x":42}}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	fn, _ := tc["function"].(map[string]any)
+	args, _ := fn["arguments"].(string)
+	if !strings.Contains(args, "42") {
+		t.Fatalf("args should contain 42 from initial input, got %q", args)
+	}
+}
+
+func TestAnthropicSSE_ToolUseDeltaOnlyNoInitialInput(t *testing.T) {
+	// content_block_start has input:{} (empty), deltas provide the real input
+	sse := strings.Join([]string{
+		`{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"m","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_z","name":"fn","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"z\":99}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`,
+		`{"type":"message_stop"}`,
+	}, "\n")
+	out, err := convertAnthropicToOpenAI([]byte(sse), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	toolCalls, _ := msg["tool_calls"].([]any)
+	tc, _ := toolCalls[0].(map[string]any)
+	fn, _ := tc["function"].(map[string]any)
+	args, _ := fn["arguments"].(string)
+	if !strings.Contains(args, "99") {
+		t.Fatalf("args should contain 99 from delta, got %q", args)
+	}
+}
+
+// =====================================================================
+// Fix 1: empty/missing type in native JSON content block
+// =====================================================================
+
+func TestAnthropicNativeJSON_EmptyTypeBlockError(t *testing.T) {
+	body := `{"id":"msg_et","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","content":[{"type":"","text":"Hi"}],"usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for empty type string")
+	}
+	if !strings.Contains(err.Error(), "missing type") {
+		t.Fatalf("error should mention missing type, got: %v", err)
+	}
+}
+
+func TestAnthropicNativeJSON_MissingTypeFieldError(t *testing.T) {
+	body := `{"id":"msg_mt","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","content":[{"text":"Hi"}],"usage":{}}`
+	_, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err == nil {
+		t.Fatal("expected error for missing type field")
+	}
+	if !strings.Contains(err.Error(), "missing type") {
+		t.Fatalf("error should mention missing type, got: %v", err)
+	}
+}
+
+func TestAnthropicNativeJSON_CustomBlockPreserved(t *testing.T) {
+	body := `{"id":"msg_cb","type":"message","role":"assistant","model":"m","stop_reason":"end_turn","content":[{"type":"text","text":"Hi"},{"type":"custom_block","data":"custom"}],"usage":{"input_tokens":1,"output_tokens":1}}`
+	out, err := convertAnthropicToOpenAI([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	var resp map[string]any
+	json.Unmarshal(out, &resp)
+	choices, _ := resp["choices"].([]any)
+	choice, _ := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	private, ok := msg["_opencode2api_anthropic_content"].([]any)
+	if !ok {
+		t.Fatal("custom_block should set hasNonText and create private field")
+	}
+	found := false
+	for _, p := range private {
+		pb, _ := p.(map[string]any)
+		if pb["type"] == "custom_block" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("custom_block should be preserved in private field")
+	}
+}
+
+// =====================================================================
+// Fix 2: extractBlockIndex platform int range
+// =====================================================================
+
+func TestExtractBlockIndex_MaxIntBoundary(t *testing.T) {
+	// Value at the exact platform maxInt should be accepted or rejected
+	// depending on whether it's exactly representable. We test that
+	// a value just below 2^31 (32-bit max) works.
+	idx, ok := extractBlockIndex(map[string]any{"index": float64(2147483647)})
+	if !ok || idx != 2147483647 {
+		// On 32-bit this would be at the boundary; on 64-bit it's fine.
+		t.Fatalf("2^31-1 should be accepted: idx=%d ok=%v", idx, ok)
+	}
+}
+
+func TestExtractBlockIndex_Above32BitMaxRejected(t *testing.T) {
+	// 2^31 exceeds 32-bit int range; on 64-bit it's fine but the test
+	// verifies the function doesn't crash. On 32-bit it should reject.
+	_, ok := extractBlockIndex(map[string]any{"index": float64(2147483648)})
+	// On 64-bit: 2^31 < maxInt(64) so it passes; on 32-bit it should reject.
+	// We just verify no panic.
+	_ = ok
+}
+
+func TestExtractBlockIndex_AboveExactFloatRangeRejected(t *testing.T) {
+	// Value above 2^53 — should always be rejected regardless of platform.
+	// 2^53+1 = 9007199254740993, but as float64 it rounds to 9007199254740992.0 (=2^53).
+	// So we use 2^54 which is definitely above the cap.
+	_, ok := extractBlockIndex(map[string]any{"index": float64(18014398509481984.0)})
+	if ok {
+		t.Fatal("value above 2^53 should be rejected")
+	}
+}
+
+// =====================================================================
+// Fix 3: transport error handler — no panic, 502, generic error
+// =====================================================================
+
+func TestChatHandler_TransportError502(t *testing.T) {
+	// Simulate a transport error by installing a transport that returns an error.
+	oldClient := httpClient
+	httpClient = &http.Client{Transport: &errorTransport{}}
+	defer func() { httpClient = oldClient }()
+
+	// Reset session state
+	ocOnce = sync.Once{}
+	ocOnce.Do(func() {})
+	ocClientVer = "test"
+	ocSessionID = "ses_test"
+	ocProjectID = "project_test"
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	chatCompletionsHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "upstream_error" {
+		t.Fatalf("type = %v, want upstream_error", errObj["type"])
+	}
+	if errObj["message"] != "upstream error" {
+		t.Fatalf("message = %v, want 'upstream error'", errObj["message"])
+	}
+}
+
+func TestClaudeHandler_TransportError502(t *testing.T) {
+	oldClient := httpClient
+	httpClient = &http.Client{Transport: &errorTransport{}}
+	defer func() { httpClient = oldClient }()
+
+	ocOnce = sync.Once{}
+	ocOnce.Do(func() {})
+	ocClientVer = "test"
+	ocSessionID = "ses_test"
+	ocProjectID = "project_test"
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "upstream_error" {
+		t.Fatalf("type = %v, want upstream_error", errObj["type"])
+	}
+	if errObj["message"] != "upstream error" {
+		t.Fatalf("message = %v, want 'upstream error'", errObj["message"])
+	}
+}
+
+func TestResponsesHandler_TransportError502(t *testing.T) {
+	oldClient := httpClient
+	httpClient = &http.Client{Transport: &errorTransport{}}
+	defer func() { httpClient = oldClient }()
+
+	ocOnce = sync.Once{}
+	ocOnce.Do(func() {})
+	ocClientVer = "test"
+	ocSessionID = "ses_test"
+	ocProjectID = "project_test"
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"primary-model","input":[]}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatal("error object missing")
+	}
+	if errObj["type"] != "upstream_error" {
+		t.Fatalf("type = %v, want upstream_error", errObj["type"])
+	}
+	if errObj["message"] != "upstream error" {
+		t.Fatalf("message = %v, want 'upstream error'", errObj["message"])
+	}
+}
+
+// errorTransport returns an error for every RoundTrip, simulating transport failure.
+type errorTransport struct{}
+
+func (e *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("connection refused")
+}
+
+func (e *errorTransport) CloseIdleConnections() {}

--- a/chat_protocol.go
+++ b/chat_protocol.go
@@ -1,5 +1,13 @@
 package main
 
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+)
+
 // normalizeFinishReason maps Anthropic stop reasons onto the closed set used
 // by Chat Completions.
 func normalizeFinishReason(reason string) string {
@@ -52,4 +60,79 @@ func numberAsFloat(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// toString converts a value to string, returning "" for non-strings.
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// validateTemperature checks an optional temperature against an inclusive
+// [min, max] range. nil (absent) and any in-range value (including the
+// bounds and explicit zero) are accepted; negative, above-max, NaN and Inf
+// values are rejected. It never clamps. An empty message means valid.
+func validateTemperature(t *float64, min, max float64) string {
+	if t == nil {
+		return ""
+	}
+	v := *t
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return fmt.Sprintf("temperature must be a finite number; got %v", v)
+	}
+	if v < min || v > max {
+		return fmt.Sprintf("temperature must be between %g and %g; got %v", min, max, v)
+	}
+	return ""
+}
+
+// writeProtocolValidation400 writes a protocol-shaped HTTP 400 error for a
+// request-side validation failure. protocol is "chat", "responses", or
+// "claude". param is the offending field name (Chat/Responses only).
+// Streaming requests also receive a plain JSON 400 before any SSE.
+func writeProtocolValidation400(w http.ResponseWriter, protocol, param, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	switch protocol {
+	case "claude":
+		json.NewEncoder(w).Encode(map[string]any{
+			"type": "error",
+			"error": map[string]string{
+				"type":    "invalid_request_error",
+				"message": message,
+			},
+		})
+	default: // "chat", "responses"
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"type":    "invalid_request_error",
+				"message": message,
+				"param":   param,
+			},
+		})
+	}
+}
+
+// validateRequestTemperature is the shared entry point used by all three
+// handlers. It returns true when the request is valid (nil or in-range) and
+// writes a protocol-shaped 400 (returning false) otherwise.
+func validateRequestTemperature(w http.ResponseWriter, t *float64, protocol string, min, max float64) bool {
+	if msg := validateTemperature(t, min, max); msg != "" {
+		writeProtocolValidation400(w, protocol, "temperature", msg)
+		return false
+	}
+	return true
+}
+
+// applyErrorPrefix prepends the stable "Error: " marker used by both the
+// Anthropic Messages and Responses request paths when a tool_result carries
+// is_error:true. It avoids producing a duplicate prefix when the output text
+// already starts with "Error:" (e.g. an upstream that echoes the error).
+func applyErrorPrefix(text string) string {
+	if strings.HasPrefix(text, "Error:") {
+		return text
+	}
+	return "Error: " + text
 }

--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,14 @@
     "high": "high"
   },
   "force_disable_thinking": false,
+  "max_tokens_cap": 131072,
+  "max_tokens_cap_per_model": {
+    "deepseek-v4-flash-free": 131072,
+    "laguna-s-2.1-free": 262144,
+    "mimo-v2.5-free": 1048576,
+    "nemotron-3-ultra-free": 1000000,
+    "nemotron-3.5-lightning-free": 1000000
+  },
   "socks5_proxies": [
     {
       "name": "local",

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,27 @@
 - 默认或 `zen:` 模式显示 Zen 目录。
 - `go:` 模式显示 Go 目录，并附带 public 可用的免费模型。
 
+## 请求校验
+
+### temperature
+
+| 入口 | 合法范围（闭区间） |
+| --- | --- |
+| `/v1/messages` | `0..1` |
+| `/v1/chat/completions` | `0..2` |
+| `/v1/responses` | `0..2` |
+
+- 缺省（`nil`）、`0`、上界均合法；负数、越上界、`NaN`/`Inf` 在调用上游前被拒绝，不 clamp。
+- 拒绝时返回 HTTP 400，`Content-Type: application/json`，形状与入口协议一致：
+  - Claude：`{"type":"error","error":{"type":"invalid_request_error","message":...}}`
+  - Chat/Responses：`{"error":{"type":"invalid_request_error","message":...,"param":"temperature"}}`
+- 流式请求同样先返回普通 JSON 400，不会开始 SSE。
+
+### 文件输入
+
+- `document`（Anthropic）/ `input_file`（Responses）是 best-effort file part，映射为 `{type:"file",file:{...}}`。并非所有上游模型支持 file 模态，上游拒绝时会透传明确错误。
+- 在受支持位置识别为文件输入但缺少任何可用 payload（无 `file_data`/`file_id`/`file_url` 或 document 无可用 `source`）时返回协议形状 HTTP 400 `invalid_request_error`，不会把 wrapper JSON 伪装成文本。
+
 ## Chat Completions
 
 ### 准确支持
@@ -42,7 +63,7 @@
 - `model`
 - `messages`
 - `stream`
-- `temperature`
+- `temperature`（闭区间 `0..2`）
 - `max_tokens`
 - `top_p`
 - `thinking`
@@ -69,21 +90,23 @@
 ### 准确支持
 
 - 字符串 `input`；含 `input_text` / `input_image` 的 message item；函数及内置工具的 call/output item
-- `instructions`、`messages`、`previous_response_id`
-- 显式零值的 `temperature`、`top_p`、`frequency_penalty`、`presence_penalty`
+- `instructions`、`messages`（使用 Chat content 形状，非 Responses `input` item 形状）、`previous_response_id`
+- 显式零值的 `temperature`（闭区间 `0..2`）、`top_p`、`frequency_penalty`、`presence_penalty`
 - `max_output_tokens`、`stop`、`user`、`parallel_tool_calls`、`stream_options`、`store`
 - 函数工具、项目已有的内置工具、`tool_choice`、`reasoning`、`metadata`
+- Anthropic-style `tool_result`（`call_id`，缺省时用 `tool_use_id`；`content` 支持 string、字符串数组、`{type:"text"|"input_text"|"output_text",text}` blocks；`is_error:true` 加 `Error: ` 前缀）
 - 正常终态 `response.completed`；长度截断终态 `response.incomplete`，reason 为 `max_output_tokens`
 
 ### Best-effort
 
 - Responses 会通过 Chat Completions 上游实现；内置工具被编码为函数工具后再还原。
 - 仅在上游实际返回 reasoning 时生成 reasoning output item。
+- `input` 中的 top-level item 或 message content 可使用 `input_file`；支持 flat 字段 `file_data`、`file_id`、`file_url`、`filename` 以及 nested `input_file` object，并映射为 `{type:"file",file:{...}}`。模型不支持 file 模态时上游可能拒绝。
 
 ### 不支持
 
-- `input_file` 等未在准确支持列表中的 input item 类型。
 - `include` 及未在上面列出的可选 Responses 字段；这些字段不会用占位值伪装成已支持。
+- `input` 中受支持位置的 `input_file` 若缺少任何可用 payload，会返回 HTTP 400，不会序列化为文本。
 
 示例：
 
@@ -109,10 +132,10 @@ curl http://127.0.0.1:8000/v1/responses \
 ### 准确支持
 
 - `system`（顶层）与消息内 `role=system` 合并为上游**唯一首条** system（`\n\n` 拼接，顶层在前）
-- `stop_sequences`、`temperature` / `top_p` / `top_k`（包括显式零值）
+- `stop_sequences`、`temperature`（闭区间 `0..1`）/ `top_p` / `top_k`（包括显式零值）
 - `metadata.user_id`：若为 JSON 串则只转发 `session_id`（避免 `device_id` 外泄）；否则原样转发
 - 文本、base64/URL image、`tool_use`、`tool_result`（包括 `is_error`）；合法的 tool result 在普通用户内容之前的顺序会被保留
-- `tool_result` 中的 image 转为紧随其后的 `role=user` + `image_url`，tool 文本保留字符串并标注 `[image attached]`
+- `tool_result` 中的 image 转为紧随其后的 `role=user` + `image_url`，tool 文本保留字符串并标注 `[image attached]`；`tool_result` 中的 document 同样转为紧随其后的 user file part 并标注 `[document attached]`
 - `tool_choice` 的 `auto`、`any`、`tool`、`none`；`disable_parallel_tool_use:true` 映射为上游 `parallel_tool_calls=false`
 - `output_config.effort` → 上游 `reasoning_effort`；`thinking.type=adaptive` 视为 enabled
 - JSON Schema 约束字段（包括 `additionalProperties`、`format`）
@@ -120,9 +143,12 @@ curl http://127.0.0.1:8000/v1/responses \
 
 ### Best-effort / 显式丢弃（可观测）
 
+- `document`（`source.type=base64`，默认 `application/pdf`；`source.type=url`）映射为 Chat content part `{type:"file",file:{...}}`，可保留 block/title 作为 `filename`。模型不支持 file 模态时上游可能拒绝；document 缺少可用 payload 时返回 HTTP 400。
 - thinking 会在没有 signature 时继续输出，以提高客户端兼容性。代理不会伪造 signature 或发送假的 `signature_delta`。
-- `redacted_thinking.data` 是不可解释的加密数据，无法无损转成 reasoning；代理忽略该内容且不记录其数据。
+- 请求历史中的 thinking `signature` 没有 Chat Completions 等价物，会被丢弃；代理仅统计历史中非空 signature block 数量到 `request_plan`（`history_signature_count`），不记录签名内容。
+- `redacted_thinking.data` 是不可解释的加密数据，无法无损转成请求侧 reasoning；请求历史中的 redacted data 会被丢弃。native Anthropic 响应中明确存在的 signature / redacted data 由第二批私有 roundtrip 字段（`_opencode2api_anthropic_content`）保留，仅用于 Claude Messages 往返，Chat/Responses 公共 payload 不会泄漏这些私有字段。
 - 无 Chat Completions 等价物的字段不进上游 body，但会绑定并记入 `request_plan` / body summary：`context_management`、`cache_control`、`anthropic-beta`、带 `type` 且无 `input_schema` 的 server tools（如 `web_search_*`）。
+- `cache_control` breakpoints 不会被透传或实现；Chat 上游的自动前缀缓存无法表达 Anthropic TTL/breakpoint，`cached_tokens` usage 仅在上游提供时映射。请求中的 `cache_control` 计入 `cache_control_blocks` 并丢弃。
 
 ### 不支持（不实现语义）
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,6 +43,40 @@ cp config.example.json config.json
 
 设为 `true` 时，服务会尽量禁用 thinking/reasoning，并从返回中移除 reasoning 内容。
 
+### `max_tokens_cap`
+
+全局默认 `max_tokens` 上限。客户端传入的 `max_tokens` 超过此值时，会被截断到此值。设为 `0` 或不填则不限制。
+
+```json
+{
+  "max_tokens_cap": 131072
+}
+```
+
+### `max_tokens_cap_per_model`
+
+按模型覆盖全局上限。键是上游模型名，值是该模型的上限。值为 `0` 表示对该模型不限制。
+
+```json
+{
+  "max_tokens_cap_per_model": {
+    "deepseek-v4-flash-free": 131072,
+    "laguna-s-2.1-free": 262144,
+    "mimo-v2.5-free": 1048576
+  }
+}
+```
+
+上游对不同模型的 `max_tokens` 限制不同，实测值如下：
+
+| 模型 | 限制类型 | 上限 |
+|------|---------|------|
+| `deepseek-v4-flash-free` | completion tokens | 131,072 |
+| `laguna-s-2.1-free` | context length | 262,144 |
+| `mimo-v2.5-free` | context length | 1,048,576 |
+| `nemotron-3-ultra-free` | context length | 1,000,000 |
+| `nemotron-3.5-lightning-free` | context length | 1,000,000 |
+
 ### `socks5_proxies`
 
 SOCKS5 代理列表。

--- a/main.go
+++ b/main.go
@@ -4319,7 +4319,7 @@ loop:
 					break loop
 				}
 				reqLogger(ctx).Error("stream read error", "error", pendingErr)
-				emitClaudeError("stream read error: " + pendingErr.Error())
+				emitClaudeError("stream read error")
 				return
 			}
 		}
@@ -6042,7 +6042,7 @@ loop:
 					break loop
 				}
 				reqLogger(ctx).Error("stream read error", "error", pendingErr)
-				emitResponseFailed("stream read error: " + pendingErr.Error())
+				emitResponseFailed("stream read error")
 				return
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -532,15 +532,17 @@ func getReqID(ctx context.Context) string {
 // ======================== 配置 ========================
 
 var (
-	port                 string
-	configPath           = "config.json"
-	modelAlias           = map[string]string{}
-	reasoningEffortMap   = map[string]string{}
-	forceDisableThinking bool
-	debugMode            bool
-	configMu             sync.RWMutex
-	storedResponses      = map[string]StoredResponseState{}
-	storedResponsesMu    sync.RWMutex
+	port                  string
+	configPath            = "config.json"
+	modelAlias            = map[string]string{}
+	reasoningEffortMap    = map[string]string{}
+	forceDisableThinking  bool
+	maxTokensCap          int
+	maxTokensCapPerModel  = map[string]int{}
+	debugMode             bool
+	configMu              sync.RWMutex
+	storedResponses       = map[string]StoredResponseState{}
+	storedResponsesMu     sync.RWMutex
 )
 
 // ======================== 管理面板认证 ========================
@@ -696,8 +698,15 @@ type AppConfig struct {
 	ModelAlias           map[string]string `json:"model_alias"`
 	ReasoningEffortMap   map[string]string `json:"reasoning_effort_map"`
 	ForceDisableThinking bool              `json:"force_disable_thinking"`
-	Socks5Proxies        []Socks5Proxy     `json:"socks5_proxies,omitempty"`
-	ActiveSocks5         string            `json:"active_socks5,omitempty"`
+	// MaxTokensCap is the global default upper bound for max_tokens sent
+	// upstream. 0 (default) means no global cap. Per-model values in
+	// MaxTokensCapPerModel take precedence.
+	MaxTokensCap int `json:"max_tokens_cap,omitempty"`
+	// MaxTokensCapPerModel overrides the global cap for specific models.
+	// A value of 0 for a model disables the cap for that model.
+	MaxTokensCapPerModel map[string]int `json:"max_tokens_cap_per_model,omitempty"`
+	Socks5Proxies        []Socks5Proxy  `json:"socks5_proxies,omitempty"`
+	ActiveSocks5         string         `json:"active_socks5,omitempty"`
 	// Socks5PaidDirect controls whether keyed/paid upstream calls bypass SOCKS5.
 	// Omitted or false (default): all traffic uses the active proxy.
 	// true: paid/keyed traffic goes direct; only public/free uses SOCKS5.
@@ -846,6 +855,10 @@ func applyConfig(cfg AppConfig) {
 		reasoningEffortMap = cfg.ReasoningEffortMap
 	}
 	forceDisableThinking = cfg.ForceDisableThinking
+	maxTokensCap = cfg.MaxTokensCap
+	if cfg.MaxTokensCapPerModel != nil {
+		maxTokensCapPerModel = cfg.MaxTokensCapPerModel
+	}
 
 	socks5Mu.Lock()
 	if cfg.Socks5Proxies != nil {
@@ -895,6 +908,18 @@ func getReasoningEffortMap() map[string]string {
 		cp[k] = v
 	}
 	return cp
+}
+
+// getMaxTokensCapForModel returns the effective max_tokens cap for the given
+// model: the per-model value if set, otherwise the global default. A return
+// value of 0 means no cap (max_tokens is forwarded as-is).
+func getMaxTokensCapForModel(model string) int {
+	configMu.RLock()
+	defer configMu.RUnlock()
+	if cap, ok := maxTokensCapPerModel[model]; ok {
+		return cap
+	}
+	return maxTokensCap
 }
 
 // ======================== Token 统计 ========================
@@ -1162,7 +1187,11 @@ func convertRequest(req *OpenAIRequest) map[string]any {
 		converted["temperature"] = *req.Temperature
 	}
 	if req.MaxTokens != nil {
-		converted["max_tokens"] = *req.MaxTokens
+		v := *req.MaxTokens
+		if cap := getMaxTokensCapForModel(req.Model); cap > 0 && v > cap {
+			v = cap
+		}
+		converted["max_tokens"] = v
 	}
 	if req.TopP != nil {
 		converted["top_p"] = *req.TopP
@@ -2695,6 +2724,8 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 		"reasoning_effort_out": mappedReasoningEffort(effortIn),
 		"tools_count":          len(req.Tools),
 		"messages_count":       len(req.Messages),
+		"max_tokens":           req.MaxTokens,
+		"max_tokens_cap":       getMaxTokensCapForModel(req.Model),
 	})
 	upstreamBody := buildUpstreamBody(&req)
 
@@ -3837,6 +3868,8 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 		"history_signature_count": countClaudeThinkingSignatures(claudeReq.Messages),
 		"client_beta_count":       countAnthropicBetas(r.Header.Get("anthropic-beta")),
 		"unsupported_blocks":      scanClaudeUnsupportedBlocks(claudeReq.Messages),
+		"max_tokens":              chatReq.MaxTokens,
+		"max_tokens_cap":          getMaxTokensCapForModel(chatReq.Model),
 	}
 	if len(skippedServerTools) > 0 {
 		plan["skipped_server_tools"] = skippedServerTools
@@ -5442,6 +5475,8 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 		"reasoning_effort_out": mappedReasoningEffort(effortIn),
 		"tools_count":          len(respReq.Tools),
 		"messages_count":       len(chatReq.Messages),
+		"max_tokens":           chatReq.MaxTokens,
+		"max_tokens_cap":       getMaxTokensCapForModel(chatReq.Model),
 	})
 
 	upstreamBody := buildUpstreamBody(&chatReq)
@@ -6336,7 +6371,7 @@ func adminConfigHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		configMu.RLock()
-		cfg := AppConfig{ModelAlias: modelAlias, ReasoningEffortMap: reasoningEffortMap, ForceDisableThinking: forceDisableThinking}
+		cfg := AppConfig{ModelAlias: modelAlias, ReasoningEffortMap: reasoningEffortMap, ForceDisableThinking: forceDisableThinking, MaxTokensCap: maxTokensCap, MaxTokensCapPerModel: maxTokensCapPerModel}
 		configMu.RUnlock()
 		socks5Mu.RLock()
 		cfg.Socks5Proxies = socks5Proxies
@@ -6345,14 +6380,16 @@ func adminConfigHandler(w http.ResponseWriter, r *http.Request) {
 		socks5Mu.RUnlock()
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"model_alias":            cfg.ModelAlias,
-			"reasoning_effort_map":   cfg.ReasoningEffortMap,
-			"force_disable_thinking": cfg.ForceDisableThinking,
-			"socks5_proxies":         cfg.Socks5Proxies,
-			"active_socks5":          cfg.ActiveSocks5,
-			"socks5_paid_direct":     cfg.Socks5PaidDirect,
-			"log_level":              getLogLevelString(),
-			"log_bodies":             getLogBodies(),
+			"model_alias":               cfg.ModelAlias,
+			"reasoning_effort_map":      cfg.ReasoningEffortMap,
+			"force_disable_thinking":    cfg.ForceDisableThinking,
+			"max_tokens_cap":            cfg.MaxTokensCap,
+			"max_tokens_cap_per_model":  cfg.MaxTokensCapPerModel,
+			"socks5_proxies":            cfg.Socks5Proxies,
+			"active_socks5":             cfg.ActiveSocks5,
+			"socks5_paid_direct":        cfg.Socks5PaidDirect,
+			"log_level":                 getLogLevelString(),
+			"log_bodies":                getLogBodies(),
 		})
 	case http.MethodPost:
 		var payload struct {
@@ -6380,6 +6417,8 @@ func adminConfigHandler(w http.ResponseWriter, r *http.Request) {
 				"aliases", len(payload.ModelAlias),
 				"effort_map", len(payload.ReasoningEffortMap),
 				"force_disable", payload.ForceDisableThinking,
+				"max_tokens_cap", payload.MaxTokensCap,
+				"max_tokens_cap_per_model", len(payload.MaxTokensCapPerModel),
 				"log_level", getLogLevelString(),
 				"log_bodies", getLogBodies(),
 			)
@@ -6673,6 +6712,25 @@ header{display:flex;align-items:flex-end;gap:16px;margin-bottom:28px;padding-bot
 </div>
 
 <div class="card">
+<h2><span class="dot" style="background:#e85d75"></span>max_tokens 上限</h2>
+<div class="form-group">
+<label>全局默认上限</label>
+<input type="number" id="maxTokensCap" class="m-input" min="0" placeholder="0 = 不限制" style="width:140px">
+<span class="hint">超过此值的 max_tokens 会被截断到此值（0 = 不限制）</span>
+</div>
+<div style="margin-bottom:12px">
+<table class="tbl" id="capTable">
+<thead><tr><th style="width:55%">模型</th><th style="width:30%">上限</th><th style="width:15%"></th></tr></thead>
+<tbody></tbody>
+</table>
+</div>
+<div class="actions">
+<button class="btn btn-primary" onclick="addCapRow()">添加模型上限</button>
+<button class="btn btn-success" onclick="saveConfig()">保存全部</button>
+</div>
+</div>
+
+<div class="card">
 <h2><span class="dot" style="background:var(--accent)"></span>模型映射</h2>
 <div style="margin-bottom:12px">
 <table class="tbl" id="aliasTable">
@@ -6711,11 +6769,11 @@ header{display:flex;align-items:flex-end;gap:16px;margin-bottom:28px;padding-bot
 </div>
 <div id="toast"></div>
 <script>
-let aliasData={},effortData={},modelList=[],socks5Data=[];
+let aliasData={},effortData={},modelList=[],socks5Data=[],capData={};
 function toggleTheme(){const d=document.documentElement;const cur=d.getAttribute('data-theme');const next=cur==='dark'?null:'dark';if(next)d.setAttribute('data-theme',next);else d.removeAttribute('data-theme');localStorage.setItem('theme',next||'light');document.querySelector('.theme-toggle').textContent=next==='dark'?'🌙':'☀'}
 (function(){const t=localStorage.getItem('theme');if(t==='dark'){document.documentElement.setAttribute('data-theme','dark');document.addEventListener('DOMContentLoaded',()=>{const b=document.querySelector('.theme-toggle');if(b)b.textContent='🌙'})}})();
 function reloadConfig(){const sy=window.scrollY;fetch('/api/reload',{method:'POST'}).then(r=>r.json()).then(d=>{showToast('会话已刷新，模型 '+d.models+' 个','success')}).catch(()=>{}).finally(()=>{loadConfig();loadStats();setTimeout(()=>window.scrollTo(0,sy),100)})}
-async function loadConfig(){const sy=window.scrollY;try{const r=await fetch('/api/config');const cfg=await r.json();document.getElementById('force_disable_thinking').checked=cfg.force_disable_thinking||false;document.getElementById('socks5_paid_direct').checked=!!cfg.socks5_paid_direct;aliasData=cfg.model_alias||{};effortData=cfg.reasoning_effort_map||{};socks5Data=cfg.socks5_proxies||[];const mr=await fetch('/v1/models');const md=await mr.json();modelList=(md.data||[]).map(m=>m.id).sort();renderAliasTable();renderEffortTable();renderSocks5Table();document.getElementById('activeSocks5').value=cfg.active_socks5||'';setTimeout(()=>window.scrollTo(0,sy),0)}catch(e){showToast('失败: '+e.message,'error')}}
+async function loadConfig(){const sy=window.scrollY;try{const r=await fetch('/api/config');const cfg=await r.json();document.getElementById('force_disable_thinking').checked=cfg.force_disable_thinking||false;document.getElementById('socks5_paid_direct').checked=!!cfg.socks5_paid_direct;aliasData=cfg.model_alias||{};effortData=cfg.reasoning_effort_map||{};socks5Data=cfg.socks5_proxies||[];capData=cfg.max_tokens_cap_per_model||{};document.getElementById('maxTokensCap').value=cfg.max_tokens_cap||'';const mr=await fetch('/v1/models');const md=await mr.json();modelList=(md.data||[]).map(m=>m.id).sort();renderAliasTable();renderEffortTable();renderSocks5Table();renderCapTable();document.getElementById('activeSocks5').value=cfg.active_socks5||'';setTimeout(()=>window.scrollTo(0,sy),0)}catch(e){showToast('失败: '+e.message,'error')}}
 function renderAliasTable(){const tb=document.querySelector('#aliasTable tbody');const ks=Object.keys(aliasData);if(!ks.length){tb.innerHTML='<tr><td colspan="3" class="empty-hint">暂无别名配置</td></tr>';return}tb.innerHTML=ks.map(k=>'<tr><td><input value="'+esc(k)+'" data-field="key"></td><td>'+modelSelectHtml(aliasData[k])+'</td><td><button class="btn btn-danger" onclick="delAlias(this)">删除</button></td></tr>').join('')}
 function modelSelectHtml(selected){let h='<select data-field="val" class="m-select">';h+='<option value="">-- 选择模型 --</option>';for(const m of modelList){h+='<option value="'+esc(m)+'"'+(selected===m?' selected':'')+'>'+esc(m)+'</option>'}h+='</select>';return h}
 function addAliasRow(){const tb=document.querySelector('#aliasTable tbody');if(tb.querySelector('.empty-hint'))tb.innerHTML='';tb.insertAdjacentHTML('beforeend','<tr><td><input value="" placeholder="例如: gpt-5.5" data-field="key"></td><td>'+modelSelectHtml('')+'</td><td><button class="btn btn-danger" onclick="delAlias(this)">删除</button></td></tr>')}
@@ -6730,7 +6788,11 @@ function addSocks5Row(){const tb=document.querySelector('#socks5Table tbody');if
 function delSocks5(i){socks5Data.splice(i,1);renderSocks5Table()}
 function collectSocks5(){const r=[];document.querySelectorAll('#socks5Table tbody tr').forEach(tr=>{const a=tr.querySelector('[data-field="addr"]');if(a&&a.value.trim())r.push({addr:a.value.trim(),name:(tr.querySelector('[data-field="name"]')||{}).value?.trim()||'',username:(tr.querySelector('[data-field="username"]')||{}).value?.trim()||'',password:(tr.querySelector('[data-field="password"]')||{}).value?.trim()||''})});socks5Data=r;return r}
 function renderSocks5Select(){const sel=document.getElementById('activeSocks5');const cur=sel.value;sel.innerHTML='<option value="">直连（不使用代理）</option>';socks5Data.forEach(p=>{if(p.addr){const label=p.name?p.name+' ('+p.addr+')':p.addr;const opt=document.createElement('option');opt.value=p.addr;opt.textContent=label;sel.appendChild(opt)}});if(socks5Data.length>=2){const opt=document.createElement('option');opt.value='__round_robin__';opt.textContent='轮询（自动切换）';sel.appendChild(opt)}sel.value=cur;if(!sel.value)sel.value='';}
-async function saveConfig(){collectAliases();collectEfforts();collectSocks5();const cfg={model_alias:aliasData,reasoning_effort_map:effortData,force_disable_thinking:document.getElementById('force_disable_thinking').checked,socks5_proxies:socks5Data,active_socks5:document.getElementById('activeSocks5').value,socks5_paid_direct:document.getElementById('socks5_paid_direct').checked};try{const r=await fetch('/api/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(cfg)});if(!r.ok)throw new Error(await r.text());showToast('配置已保存','success');loadConfig()}catch(e){showToast('保存失败: '+e.message,'error')}}
+async function saveConfig(){collectAliases();collectEfforts();collectSocks5();collectCaps();const cfg={model_alias:aliasData,reasoning_effort_map:effortData,force_disable_thinking:document.getElementById('force_disable_thinking').checked,max_tokens_cap:parseInt(document.getElementById('maxTokensCap').value)||0,max_tokens_cap_per_model:capData,socks5_proxies:socks5Data,active_socks5:document.getElementById('activeSocks5').value,socks5_paid_direct:document.getElementById('socks5_paid_direct').checked};try{const r=await fetch('/api/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(cfg)});if(!r.ok)throw new Error(await r.text());showToast('配置已保存','success');loadConfig()}catch(e){showToast('保存失败: '+e.message,'error')}}
+function renderCapTable(){const tb=document.querySelector('#capTable tbody');const ks=Object.keys(capData);if(!ks.length){tb.innerHTML='<tr><td colspan="3" class="empty-hint">暂无模型上限配置</td></tr>';return}tb.innerHTML=ks.map(k=>'<tr><td>'+modelSelectHtml(k)+'</td><td><input type="number" value="'+capData[k]+'" data-field="cap" min="0" style="width:100px"></td><td><button class="btn btn-danger" onclick="delCap(this)">删除</button></td></tr>').join('')}
+function addCapRow(){const tb=document.querySelector('#capTable tbody');const tr=document.createElement('tr');tr.innerHTML='<td>'+modelSelectHtml('')+'</td><td><input type="number" value="0" data-field="cap" min="0" style="width:100px"></td><td><button class="btn btn-danger" onclick="delCap(this)">删除</button></td>';tb.appendChild(tr);if(tb.querySelector('.empty-hint'))tb.innerHTML=''}
+function collectCaps(){capData={};document.querySelectorAll('#capTable tbody tr').forEach(tr=>{const sel=tr.querySelector('[data-field=key]');const inp=tr.querySelector('[data-field=cap]');if(sel&&inp){const k=sel.value;if(k){const v=parseInt(inp.value)||0;capData[k]=v}}})}
+function delCap(btn){btn.closest('tr').remove();if(!document.querySelector('#capTable tbody tr'))renderCapTable()}
 function esc(s){const d=document.createElement('div');d.textContent=s;return d.innerHTML}
 function showToast(msg,t){const e=document.getElementById('toast');e.textContent=msg;e.className=t+' show';clearTimeout(e._tid);e._tid=setTimeout(()=>e.classList.remove('show'),2500)}
 async function resetStats(){if(!confirm('确认清空所有 Token 统计？\n此操作不可撤销。'))return;const s=document.getElementById('resetStatus');s.textContent='清空中...';try{const r=await fetch('/api/stats',{method:'DELETE'});if(!r.ok)throw new Error(await r.text());document.getElementById('statsContent').innerHTML='<div class="empty-hint">暂无数据</div>';s.textContent='已清空';setTimeout(()=>s.textContent='',2000)}catch(e){s.textContent='失败: '+e.message}}

--- a/main.go
+++ b/main.go
@@ -532,17 +532,17 @@ func getReqID(ctx context.Context) string {
 // ======================== 配置 ========================
 
 var (
-	port                  string
-	configPath            = "config.json"
-	modelAlias            = map[string]string{}
-	reasoningEffortMap    = map[string]string{}
-	forceDisableThinking  bool
-	maxTokensCap          int
-	maxTokensCapPerModel  = map[string]int{}
-	debugMode             bool
-	configMu              sync.RWMutex
-	storedResponses       = map[string]StoredResponseState{}
-	storedResponsesMu     sync.RWMutex
+	port                 string
+	configPath           = "config.json"
+	modelAlias           = map[string]string{}
+	reasoningEffortMap   = map[string]string{}
+	forceDisableThinking bool
+	maxTokensCap         int
+	maxTokensCapPerModel = map[string]int{}
+	debugMode            bool
+	configMu             sync.RWMutex
+	storedResponses      = map[string]StoredResponseState{}
+	storedResponsesMu    sync.RWMutex
 )
 
 // ======================== 管理面板认证 ========================
@@ -6380,16 +6380,16 @@ func adminConfigHandler(w http.ResponseWriter, r *http.Request) {
 		socks5Mu.RUnlock()
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"model_alias":               cfg.ModelAlias,
-			"reasoning_effort_map":      cfg.ReasoningEffortMap,
-			"force_disable_thinking":    cfg.ForceDisableThinking,
-			"max_tokens_cap":            cfg.MaxTokensCap,
-			"max_tokens_cap_per_model":  cfg.MaxTokensCapPerModel,
-			"socks5_proxies":            cfg.Socks5Proxies,
-			"active_socks5":             cfg.ActiveSocks5,
-			"socks5_paid_direct":        cfg.Socks5PaidDirect,
-			"log_level":                 getLogLevelString(),
-			"log_bodies":                getLogBodies(),
+			"model_alias":              cfg.ModelAlias,
+			"reasoning_effort_map":     cfg.ReasoningEffortMap,
+			"force_disable_thinking":   cfg.ForceDisableThinking,
+			"max_tokens_cap":           cfg.MaxTokensCap,
+			"max_tokens_cap_per_model": cfg.MaxTokensCapPerModel,
+			"socks5_proxies":           cfg.Socks5Proxies,
+			"active_socks5":            cfg.ActiveSocks5,
+			"socks5_paid_direct":       cfg.Socks5PaidDirect,
+			"log_level":                getLogLevelString(),
+			"log_bodies":               getLogBodies(),
 		})
 	case http.MethodPost:
 		var payload struct {

--- a/main.go
+++ b/main.go
@@ -5,17 +5,22 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -729,6 +734,7 @@ type ClaudeContent struct {
 	Text      string `json:"text,omitempty"`
 	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
 	ID        string `json:"id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Input     any    `json:"input,omitempty"`
@@ -737,10 +743,11 @@ type ClaudeContent struct {
 }
 
 type ClaudeTool struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	InputSchema any    `json:"input_schema"`
-	Type        string `json:"type,omitempty"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+	InputSchema  any    `json:"input_schema"`
+	Type         string `json:"type,omitempty"`
+	CacheControl any    `json:"cache_control,omitempty"`
 }
 
 type ClaudeResponse struct {
@@ -1226,29 +1233,12 @@ func isAnthropicFormat(body []byte) bool {
 		if len(line) == 0 {
 			continue
 		}
-		var event map[string]any
-		if err := json.Unmarshal(line, &event); err != nil {
-			continue
+		// Support "data: " prefixed SSE lines.
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			line = bytes.TrimSpace(line[6:])
+		} else if bytes.HasPrefix(line, []byte("data:")) {
+			line = bytes.TrimSpace(line[5:])
 		}
-		typ, _ := event["type"].(string)
-		switch typ {
-		case "message_start", "content_block_start", "content_block_delta",
-			"content_block_stop", "message_delta", "message_stop", "ping":
-			return true
-		}
-		return false
-	}
-	return false
-}
-
-func parseAnthropicSSE(body []byte) (map[string]any, string, []map[string]any) {
-	lines := bytes.Split(body, []byte("\n"))
-	var anthropicMsg map[string]any
-	var textBuilder, currentToolInputBuilder strings.Builder
-	var currentToolUse map[string]any
-	var toolUseBlocks []map[string]any
-	for _, line := range lines {
-		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}
@@ -1258,63 +1248,479 @@ func parseAnthropicSSE(body []byte) (map[string]any, string, []map[string]any) {
 		}
 		typ, _ := event["type"].(string)
 		switch typ {
+		case "message_start", "content_block_start", "content_block_delta",
+			"content_block_stop", "message_delta", "message_stop", "ping",
+			"error":
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// anthropicBlockState tracks per-index content block reconstruction.
+type anthropicBlockState struct {
+	blockType     string
+	id            string
+	name          string
+	signature     string
+	data          string
+	textBuilder   strings.Builder
+	thinkBuilder  strings.Builder
+	jsonBuilder   strings.Builder
+	initialInput  any
+	sawInputDelta bool
+	started       bool
+	stopped       bool
+}
+
+// mergeUsageMaps merges src into dst. Anthropic usage values are snapshots /
+// cumulative: a field present in src always replaces the value in dst (including
+// 0). Nested maps are recursively merged. Fields absent from src are retained.
+func mergeUsageMaps(dst any, src map[string]any) map[string]any {
+	if src == nil {
+		if dm, ok := dst.(map[string]any); ok {
+			return dm
+		}
+		return nil
+	}
+	var result map[string]any
+	if dm, ok := dst.(map[string]any); ok {
+		result = make(map[string]any, len(dm))
+		for k, v := range dm {
+			result[k] = v
+		}
+	} else {
+		result = map[string]any{}
+	}
+	for k, v := range src {
+		if existing, ok := result[k]; ok {
+			if srcMap, ok := v.(map[string]any); ok {
+				if existing != nil {
+					result[k] = mergeUsageMaps(existing, srcMap)
+					continue
+				}
+			}
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// parseAnthropicSSE reconstructs content blocks from Anthropic SSE events.
+// It manages parallel blocks by index, handles text_delta, thinking_delta,
+// signature_delta, and input_json_delta. Returns the reconstructed message,
+// ordered content blocks (sorted by numeric index ascending), and an error
+// if the stream is malformed/truncated.
+//
+// Supported line formats:
+//   - raw JSON per line (one event per line)
+//   - standard SSE: "data: <json>", "event: <name>", comment lines starting
+//     with ":" (ignored as metadata)
+//
+// Malformed/truncated conditions that return an error:
+//   - missing message_stop
+//   - error event from upstream
+//   - malformed event JSON
+//   - delta for an unknown/un-started index
+//   - content_block_stop for an unknown/un-started index
+//   - duplicate content_block_start for the same index
+//   - message_stop with unclosed (not-yet-stopped) blocks
+//   - malformed tool_use input JSON
+func parseAnthropicSSE(body []byte) (map[string]any, []map[string]any, error) {
+	lines := bytes.Split(body, []byte("\n"))
+	var anthropicMsg map[string]any
+	blocks := map[int]*anthropicBlockState{}
+	sawMessageStop := false
+	messageStartCount := 0
+
+	for _, rawLine := range lines {
+		line := bytes.TrimSpace(rawLine)
+		if len(line) == 0 {
+			continue
+		}
+		// Standard SSE metadata lines: "event: ...", "id: ...", comment ": ..."
+		if bytes.HasPrefix(line, []byte("event:")) ||
+			bytes.HasPrefix(line, []byte("id:")) ||
+			bytes.HasPrefix(line, []byte(":")) {
+			continue
+		}
+		// Support "data: " prefixed SSE lines.
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			line = bytes.TrimSpace(line[6:])
+		} else if bytes.HasPrefix(line, []byte("data:")) {
+			line = bytes.TrimSpace(line[5:])
+		}
+		if len(line) == 0 {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal(line, &event); err != nil {
+			return nil, nil, fmt.Errorf("malformed SSE event JSON: %w", err)
+		}
+		typ, _ := event["type"].(string)
+
+		// After message_stop, only ping events and comment/metadata lines
+		// are allowed. Comment/metadata lines are already filtered above.
+		// Any other event is an error.
+		if sawMessageStop && typ != "ping" {
+			return nil, nil, fmt.Errorf("unexpected event %q after message_stop", typ)
+		}
+
+		switch typ {
 		case "message_start":
-			if m, ok := event["message"].(map[string]any); ok {
-				anthropicMsg = m
+			messageStartCount++
+			if messageStartCount > 1 {
+				return nil, nil, fmt.Errorf("multiple message_start events in SSE stream")
 			}
+			m, ok := event["message"].(map[string]any)
+			if !ok || m == nil {
+				return nil, nil, fmt.Errorf("message_start missing non-nil message object")
+			}
+			anthropicMsg = m
 		case "content_block_start":
-			if cb, ok := event["content_block"].(map[string]any); ok {
-				if cbType, _ := cb["type"].(string); cbType == "tool_use" {
-					currentToolUse = cb
-					currentToolInputBuilder.Reset()
-				}
+			if messageStartCount == 0 {
+				return nil, nil, fmt.Errorf("content_block_start before message_start")
 			}
-		case "content_block_delta":
-			if delta, ok := event["delta"].(map[string]any); ok {
-				if t, ok := delta["text"].(string); ok {
-					textBuilder.WriteString(t)
+			idx, ok := extractBlockIndex(event)
+			if !ok {
+				return nil, nil, fmt.Errorf("content_block_start missing valid non-negative integer index")
+			}
+			if existing, ok := blocks[idx]; ok && existing.started {
+				return nil, nil, fmt.Errorf("duplicate content_block_start for index %d", idx)
+			}
+			cb, _ := event["content_block"].(map[string]any)
+			cbType, _ := cb["type"].(string)
+			if cbType == "" {
+				return nil, nil, fmt.Errorf("content_block_start missing content_block type")
+			}
+			if cbType != "text" && cbType != "thinking" && cbType != "redacted_thinking" && cbType != "tool_use" {
+				return nil, nil, fmt.Errorf("content_block_start unsupported type %q", cbType)
+			}
+			st := &anthropicBlockState{blockType: cbType, started: true}
+			if cb != nil {
+				if id, ok := cb["id"].(string); ok {
+					st.id = id
 				}
-				if dt, _ := delta["type"].(string); dt == "input_json_delta" {
-					if partial, ok := delta["partial_json"].(string); ok {
-						currentToolInputBuilder.WriteString(partial)
+				if name, ok := cb["name"].(string); ok {
+					st.name = name
+				}
+				// tool_use must have a non-empty name.
+				if cbType == "tool_use" && st.name == "" {
+					return nil, nil, fmt.Errorf("tool_use content_block_start missing non-empty name")
+				}
+				if sig, ok := cb["signature"].(string); ok {
+					st.signature = sig
+				}
+				if d, ok := cb["data"].(string); ok {
+					st.data = d
+				}
+				// Preserve initial text if provided.
+				if t, ok := cb["text"].(string); ok && t != "" {
+					st.textBuilder.WriteString(t)
+				}
+				if t, ok := cb["thinking"].(string); ok && t != "" {
+					st.thinkBuilder.WriteString(t)
+				}
+				// Preserve initial input if provided as a non-empty value.
+				// In Anthropic SSE, content_block_start.input is typically {}
+				// and the actual input arrives via input_json_delta partials.
+				// Store separately so initial input and partial deltas are not
+				// concatenated into invalid JSON.
+				if input, ok := cb["input"]; ok && input != nil {
+					if inputStr, ok := input.(string); ok && inputStr != "" {
+						st.initialInput = inputStr
+					} else if m, ok := input.(map[string]any); ok && len(m) > 0 {
+						st.initialInput = input
 					}
 				}
 			}
-		case "content_block_stop":
-			if currentToolUse != nil {
-				inputStr := currentToolInputBuilder.String()
-				var input any = inputStr
-				var parsed any
-				if json.Unmarshal([]byte(inputStr), &parsed) == nil {
-					input = parsed
-				}
-				currentToolUse["input"] = input
-				toolUseBlocks = append(toolUseBlocks, currentToolUse)
-				currentToolUse = nil
+			blocks[idx] = st
+		case "content_block_delta":
+			if messageStartCount == 0 {
+				return nil, nil, fmt.Errorf("content_block_delta before message_start")
 			}
-		case "message_delta":
-			if delta, ok := event["delta"].(map[string]any); ok {
-				if anthropicMsg == nil {
-					anthropicMsg = map[string]any{}
+			idx, ok := extractBlockIndex(event)
+			if !ok {
+				return nil, nil, fmt.Errorf("content_block_delta missing valid non-negative integer index")
+			}
+			st, ok := blocks[idx]
+			if !ok || !st.started {
+				return nil, nil, fmt.Errorf("content_block_delta for unknown index %d", idx)
+			}
+			if st.stopped {
+				return nil, nil, fmt.Errorf("content_block_delta for already-stopped index %d", idx)
+			}
+			delta, ok := event["delta"].(map[string]any)
+			if !ok || delta == nil {
+				return nil, nil, fmt.Errorf("content_block_delta for index %d missing delta object", idx)
+			}
+			dt, _ := delta["type"].(string)
+			if dt == "" {
+				return nil, nil, fmt.Errorf("content_block_delta for index %d missing delta type", idx)
+			}
+			switch dt {
+			case "text_delta":
+				if t, ok := delta["text"].(string); ok {
+					st.textBuilder.WriteString(t)
 				}
+			case "thinking_delta":
+				if t, ok := delta["thinking"].(string); ok {
+					st.thinkBuilder.WriteString(t)
+				}
+			case "signature_delta":
+				if sig, ok := delta["signature"].(string); ok {
+					st.signature += sig
+				}
+			case "input_json_delta":
+				if partial, ok := delta["partial_json"].(string); ok {
+					st.jsonBuilder.WriteString(partial)
+					st.sawInputDelta = true
+				}
+			default:
+				// Unknown delta type: ignore.
+			}
+		case "content_block_stop":
+			if messageStartCount == 0 {
+				return nil, nil, fmt.Errorf("content_block_stop before message_start")
+			}
+			idx, ok := extractBlockIndex(event)
+			if !ok {
+				return nil, nil, fmt.Errorf("content_block_stop missing valid non-negative integer index")
+			}
+			st, ok := blocks[idx]
+			if !ok || !st.started {
+				return nil, nil, fmt.Errorf("content_block_stop for unknown index %d", idx)
+			}
+			if st.stopped {
+				return nil, nil, fmt.Errorf("duplicate content_block_stop for index %d", idx)
+			}
+			st.stopped = true
+		case "message_delta":
+			if messageStartCount == 0 {
+				return nil, nil, fmt.Errorf("message_delta before message_start")
+			}
+			if anthropicMsg == nil {
+				anthropicMsg = map[string]any{}
+			}
+			if delta, ok := event["delta"].(map[string]any); ok {
 				if stop, ok := delta["stop_reason"].(string); ok {
 					anthropicMsg["stop_reason"] = stop
 				}
+			}
+			// message_delta usage is at the event top level (Anthropic spec).
+			if usage, ok := event["usage"].(map[string]any); ok {
+				anthropicMsg["usage"] = mergeUsageMaps(anthropicMsg["usage"], usage)
+			} else if delta, ok := event["delta"].(map[string]any); ok {
 				if usage, ok := delta["usage"].(map[string]any); ok {
-					anthropicMsg["usage"] = usage
+					anthropicMsg["usage"] = mergeUsageMaps(anthropicMsg["usage"], usage)
 				}
 			}
 		case "message_stop":
+			// Validate at message_stop time: must have message_start,
+			// all blocks stopped, and non-empty stop_reason.
+			if messageStartCount == 0 {
+				return nil, nil, fmt.Errorf("message_stop before message_start")
+			}
+			for idx, st := range blocks {
+				if st != nil && st.started && !st.stopped {
+					return nil, nil, fmt.Errorf("message_stop with unclosed block at index %d", idx)
+				}
+			}
+			stopReason, _ := anthropicMsg["stop_reason"].(string)
+			if stopReason == "" {
+				return nil, nil, fmt.Errorf("message_stop without stop_reason")
+			}
+			sawMessageStop = true
 		case "error":
-			return nil, "", nil
+			errType := "api_error"
+			errMsg := "upstream Anthropic error"
+			if errMap, ok := event["error"].(map[string]any); ok {
+				if t, ok := errMap["type"].(string); ok && t != "" {
+					errType = t
+				}
+				if m, ok := errMap["message"].(string); ok && m != "" {
+					errMsg = m
+				}
+			}
+			return nil, nil, &anthropicProtocolError{errType: errType, message: errMsg}
+		default:
+			// Unknown event type: ignore.
 		}
 	}
-	return anthropicMsg, textBuilder.String(), toolUseBlocks
+
+	if messageStartCount == 0 {
+		return nil, nil, fmt.Errorf("anthropic SSE stream missing message_start")
+	}
+	if !sawMessageStop {
+		return nil, nil, fmt.Errorf("anthropic SSE stream ended without message_stop")
+	}
+
+	// Build ordered content blocks sorted by numeric index ascending.
+	indices := make([]int, 0, len(blocks))
+	for idx := range blocks {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	var contentBlocks []map[string]any
+	for _, idx := range indices {
+		st := blocks[idx]
+		if st == nil {
+			continue
+		}
+		switch st.blockType {
+		case "text":
+			contentBlocks = append(contentBlocks, map[string]any{
+				"type": "text",
+				"text": st.textBuilder.String(),
+			})
+		case "thinking":
+			blk := map[string]any{
+				"type":     "thinking",
+				"thinking": st.thinkBuilder.String(),
+			}
+			if st.signature != "" {
+				blk["signature"] = st.signature
+			}
+			contentBlocks = append(contentBlocks, blk)
+		case "redacted_thinking":
+			blk := map[string]any{
+				"type": "redacted_thinking",
+			}
+			if st.data != "" {
+				blk["data"] = st.data
+			}
+			contentBlocks = append(contentBlocks, blk)
+		case "tool_use":
+			var input any
+			if st.sawInputDelta {
+				// Parse accumulated partial JSON deltas.
+				inputStr := st.jsonBuilder.String()
+				if inputStr != "" {
+					var parsed any
+					if err := json.Unmarshal([]byte(inputStr), &parsed); err != nil {
+						return nil, nil, fmt.Errorf("malformed tool_use input JSON for index %d: %w", idx, err)
+					}
+					input = parsed
+				} else {
+					input = map[string]any{}
+				}
+			} else if st.initialInput != nil {
+				// Use initial input from content_block_start.
+				if inputStr, ok := st.initialInput.(string); ok {
+					var parsed any
+					if err := json.Unmarshal([]byte(inputStr), &parsed); err != nil {
+						return nil, nil, fmt.Errorf("malformed tool_use initial input for index %d: %w", idx, err)
+					}
+					input = parsed
+				} else {
+					input = st.initialInput
+				}
+			} else {
+				input = map[string]any{}
+			}
+			blk := map[string]any{
+				"type":  "tool_use",
+				"input": input,
+			}
+			if st.id != "" {
+				blk["id"] = st.id
+			}
+			if st.name != "" {
+				blk["name"] = st.name
+			}
+			contentBlocks = append(contentBlocks, blk)
+		default:
+			// Unknown block type: skip.
+		}
+	}
+
+	if anthropicMsg == nil {
+		anthropicMsg = map[string]any{}
+	}
+	return anthropicMsg, contentBlocks, nil
 }
 
-func buildOpenAIResponse(anthropicMsg map[string]any, text string, toolUseBlocks []map[string]any, modelID string) []byte {
+// extractBlockIndex extracts a non-negative integer index from an SSE event.
+// Returns false if the index is missing, not a JSON number, is a float with
+// a fractional part, is negative, NaN, Inf, or exceeds the platform's int range.
+// The platform maxInt is checked BEFORE the int(f) conversion to avoid
+// undefined/saturating behavior on overflow.
+func extractBlockIndex(event map[string]any) (int, bool) {
+	rawIdx, ok := event["index"]
+	if !ok || rawIdx == nil {
+		return 0, false
+	}
+	f, ok := rawIdx.(float64)
+	if !ok {
+		return 0, false
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	if math.Trunc(f) != f || f < 0 {
+		return 0, false
+	}
+	// Check platform int range BEFORE converting, to avoid overflow.
+	// On 64-bit: maxInt = 2^63-1; on 32-bit: maxInt = 2^31-1.
+	// float64 can't represent all int64 values, so also cap at 2^53
+	// (where all integers are exactly representable as float64).
+	maxInt := float64(1<<(strconv.IntSize-1) - 1)
+	if f > maxInt {
+		return 0, false
+	}
+	// Also reject values above the float64 exact-integer upper bound.
+	if f > float64(1<<53) {
+		return 0, false
+	}
+	idx := int(f)
+	if float64(idx) != f {
+		return 0, false
+	}
+	return idx, true
+}
+
+// deterministicResponseID returns a deterministic response ID for the given
+// prefix and upstream ID. If id already has the prefix (with a non-empty
+// suffix), it is kept as-is. Otherwise, a stable hex digest derived from
+// sha256(id) is appended to the prefix so the same input always produces the
+// same output. An empty id gets a random suffix (callers should cache).
+func deterministicResponseID(prefix, id string) string {
+	if strings.HasPrefix(id, prefix) && len(id) > len(prefix) {
+		return id
+	}
+	if id == "" {
+		return prefix + randomString(24)
+	}
+	h := sha256.Sum256([]byte(id))
+	return prefix + hex.EncodeToString(h[:16])
+}
+
+// normalizeChatResponseID ensures a Chat response ID has the chatcmpl- prefix.
+func normalizeChatResponseID(id string) string {
+	return deterministicResponseID("chatcmpl-", id)
+}
+
+// normalizeResponsesID ensures a Responses response ID has the resp_ prefix.
+func normalizeResponsesID(id string) string {
+	return deterministicResponseID("resp_", id)
+}
+
+// normalizeClaudeMessageID ensures a Claude message ID has the msg_ prefix.
+func normalizeClaudeMessageID(id string) string {
+	return deterministicResponseID("msg_", id)
+}
+
+// buildOpenAIResponse constructs a Chat Completions response from an Anthropic
+// message and ordered content blocks. Text blocks are concatenated into a
+// content string (preserving original order), thinking goes to
+// reasoning_content, tool_use blocks populate tool_calls. A private field
+// _opencode2api_anthropic_content preserves the original ordered blocks for
+// Claude roundtrip; convertResponse strips it before responding to clients.
+func buildOpenAIResponse(anthropicMsg map[string]any, contentBlocks []map[string]any, modelID string) ([]byte, error) {
 	if anthropicMsg == nil {
-		return nil
+		return nil, fmt.Errorf("no Anthropic message to convert")
 	}
 	now := time.Now().Unix()
 	role, _ := anthropicMsg["role"].(string)
@@ -1323,32 +1729,100 @@ func buildOpenAIResponse(anthropicMsg map[string]any, text string, toolUseBlocks
 	}
 	finishReason, _ := anthropicMsg["stop_reason"].(string)
 	finishReason = normalizeFinishReason(finishReason)
-	choice := map[string]any{
-		"index":         0,
-		"message":       map[string]any{"role": role, "content": text},
-		"finish_reason": finishReason,
-	}
-	if len(toolUseBlocks) > 0 {
-		var toolCalls []map[string]any
-		for _, tb := range toolUseBlocks {
-			toolInput := tb["input"]
-			argsJSON, _ := json.Marshal(toolInput)
+
+	var textBuilder strings.Builder
+	var reasoningContent string
+	var toolCalls []map[string]any
+	hasNonText := false
+
+	for _, blk := range contentBlocks {
+		bt, _ := blk["type"].(string)
+		switch bt {
+		case "text":
+			if t, ok := blk["text"].(string); ok {
+				textBuilder.WriteString(t)
+			}
+		case "thinking":
+			hasNonText = true
+			if t, ok := blk["thinking"].(string); ok {
+				if reasoningContent != "" {
+					reasoningContent += "\n"
+				}
+				reasoningContent += t
+			}
+		case "redacted_thinking":
+			hasNonText = true
+		case "tool_use":
+			hasNonText = true
+			input := blk["input"]
+			if input == nil {
+				input = map[string]any{}
+			}
+			argsJSON, _ := json.Marshal(input)
+			toolID, _ := blk["id"].(string)
+			if toolID == "" {
+				toolID = "toolu_" + randomString(12)
+				blk["id"] = toolID
+			}
+			toolName, _ := blk["name"].(string)
 			toolCalls = append(toolCalls, map[string]any{
-				"id":   tb["id"],
+				"id":   toolID,
 				"type": "function",
 				"function": map[string]any{
-					"name":      tb["name"],
+					"name":      toolName,
 					"arguments": string(argsJSON),
 				},
 			})
-		}
-		choice["message"].(map[string]any)["tool_calls"] = toolCalls
-		if text == "" {
-			choice["message"].(map[string]any)["content"] = nil
+		default:
+			// Unknown non-empty block type: preserve for private roundtrip.
+			if bt != "" {
+				hasNonText = true
+			}
 		}
 	}
+
+	msg := map[string]any{"role": role}
+
+	// Determine content: if only text blocks, use a string for compatibility.
+	textStr := textBuilder.String()
+	if !hasNonText {
+		msg["content"] = textStr
+	} else {
+		if textStr != "" {
+			msg["content"] = textStr
+		} else {
+			msg["content"] = nil
+		}
+	}
+
+	if reasoningContent != "" {
+		msg["reasoning_content"] = reasoningContent
+	}
+
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
+	}
+
+	// Private field for Claude roundtrip: preserves original ordered blocks
+	// whenever any non-text native block exists (thinking, redacted_thinking,
+	// tool_use). Generated tool IDs are written back to the blocks so that
+	// Claude roundtrip associations are consistent.
+	if hasNonText {
+		privateBlocks := make([]map[string]any, 0, len(contentBlocks))
+		for _, blk := range contentBlocks {
+			privateBlocks = append(privateBlocks, blk)
+		}
+		msg["_opencode2api_anthropic_content"] = privateBlocks
+	}
+
+	choice := map[string]any{
+		"index":         0,
+		"message":       msg,
+		"finish_reason": finishReason,
+	}
+
 	resp := map[string]any{
-		"id":      anthropicMsg["id"],
+		"id":      normalizeChatResponseID(toString(anthropicMsg["id"])),
 		"object":  "chat.completion",
 		"created": now,
 		"model":   modelID,
@@ -1357,48 +1831,98 @@ func buildOpenAIResponse(anthropicMsg map[string]any, text string, toolUseBlocks
 	if usage, ok := anthropicMsg["usage"].(map[string]any); ok {
 		resp["usage"] = anthropicUsageToChat(usage)
 	}
-	result, _ := json.Marshal(resp)
-	return result
+	result, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Chat response: %w", err)
+	}
+	return result, nil
 }
 
-func convertAnthropicMessageToOpenAI(msg map[string]any, modelID string) []byte {
+// convertAnthropicMessageToOpenAI converts a native Anthropic message JSON
+// (non-streaming) to Chat Completions format. Returns an error on malformed input.
+func convertAnthropicMessageToOpenAI(msg map[string]any, modelID string) ([]byte, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("no Anthropic message to convert")
+	}
 	if msg["model"] == nil {
 		msg["model"] = modelID
 	}
-	var textBuilder strings.Builder
-	var toolUses []map[string]any
-	if content, ok := msg["content"].([]any); ok {
-		for _, c := range content {
-			if block, ok := c.(map[string]any); ok {
-				switch block["type"] {
-				case "text":
-					if t, ok := block["text"].(string); ok {
-						textBuilder.WriteString(t)
-					}
-				case "tool_use":
-					toolUses = append(toolUses, block)
+	// Direct non-stream message requires a content array.
+	content, ok := msg["content"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("anthropic message missing content array")
+	}
+	var contentBlocks []map[string]any
+	for _, c := range content {
+		block, ok := c.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("anthropic message content contains non-object block")
+		}
+		bt, _ := block["type"].(string)
+		switch bt {
+		case "text", "thinking", "redacted_thinking":
+			// Supported types.
+		case "tool_use":
+			// tool_use must have a non-empty name.
+			name, _ := block["name"].(string)
+			if name == "" {
+				return nil, fmt.Errorf("tool_use block missing non-empty name")
+			}
+			// tool_use input must be JSON-marshalable.
+			if input, exists := block["input"]; exists && input != nil {
+				if _, err := json.Marshal(input); err != nil {
+					return nil, fmt.Errorf("tool_use input not JSON-marshalable: %w", err)
 				}
 			}
+		default:
+			if bt == "" {
+				return nil, fmt.Errorf("anthropic message content block missing type")
+			}
+			// Unknown non-empty block type: keep in private blocks for
+			// potential roundtrip; public Chat ignores it.
 		}
+		contentBlocks = append(contentBlocks, block)
 	}
-	return buildOpenAIResponse(msg, textBuilder.String(), toolUses, modelID)
+	// Direct non-stream message requires a non-empty stop_reason.
+	stopReason, _ := msg["stop_reason"].(string)
+	if stopReason == "" {
+		return nil, fmt.Errorf("anthropic message missing stop_reason")
+	}
+	return buildOpenAIResponse(msg, contentBlocks, modelID)
 }
 
-func convertAnthropicToOpenAI(body []byte, modelID string) []byte {
+// convertAnthropicToOpenAI detects whether the upstream body is a native
+// Anthropic message (JSON) or SSE stream, and converts it to Chat Completions.
+// Returns an error if the body is malformed, truncated, or contains an error event.
+func convertAnthropicToOpenAI(body []byte, modelID string) ([]byte, error) {
 	var singleMsg map[string]any
 	if json.Unmarshal(body, &singleMsg) == nil {
 		if typ, _ := singleMsg["type"].(string); typ == "message" {
 			return convertAnthropicMessageToOpenAI(singleMsg, modelID)
 		}
+		// Could be a single error object.
+		if typ, _ := singleMsg["type"].(string); typ == "error" {
+			errType := "api_error"
+			errMsg := "upstream Anthropic error"
+			if errMap, ok := singleMsg["error"].(map[string]any); ok {
+				if t, ok := errMap["type"].(string); ok && t != "" {
+					errType = t
+				}
+				if m, ok := errMap["message"].(string); ok && m != "" {
+					errMsg = m
+				}
+			}
+			return nil, &anthropicProtocolError{errType: errType, message: errMsg}
+		}
 	}
-	msg, text, toolUses := parseAnthropicSSE(body)
-	if msg == nil {
-		return body
+	msg, contentBlocks, err := parseAnthropicSSE(body)
+	if err != nil {
+		return nil, err
 	}
 	if msg["model"] == nil {
 		msg["model"] = modelID
 	}
-	return buildOpenAIResponse(msg, text, toolUses, modelID)
+	return buildOpenAIResponse(msg, contentBlocks, modelID)
 }
 
 // ======================== 响应清理 ========================
@@ -1490,6 +2014,9 @@ func convertStreamChunkWithUsage(line string, keepReasoning bool) (string, map[s
 	if !ok || len(choices) == 0 {
 		// Chat Completions deliberately uses an empty choices array for the
 		// terminal usage chunk. It is part of the client-visible stream.
+		if id, ok := raw["id"].(string); ok && id != "" {
+			raw["id"] = normalizeChatResponseID(id)
+		}
 		delete(raw, "cost")
 		converted, err := json.Marshal(raw)
 		if err != nil {
@@ -1512,6 +2039,7 @@ func convertStreamChunkWithUsage(line string, keepReasoning bool) (string, map[s
 			if !keepReasoning {
 				delete(msg, "reasoning_content")
 			}
+			delete(msg, "_opencode2api_anthropic_content")
 			choice["message"] = msg
 		}
 		if v, ok := choice["logprobs"]; ok && v == nil {
@@ -1529,6 +2057,9 @@ func convertStreamChunkWithUsage(line string, keepReasoning bool) (string, map[s
 	if v, ok := raw["usage"]; ok && v == nil {
 		delete(raw, "usage")
 	}
+	if id, ok := raw["id"].(string); ok && id != "" {
+		raw["id"] = normalizeChatResponseID(id)
+	}
 	delete(raw, "cost")
 	converted, err := json.Marshal(raw)
 	if err != nil {
@@ -1543,6 +2074,9 @@ func convertResponse(data []byte, keepReasoning bool) ([]byte, error) {
 		slog.Warn("convertResponse unmarshal failed", "error", err)
 		return data, nil
 	}
+	if id, ok := raw["id"].(string); ok && id != "" {
+		raw["id"] = normalizeChatResponseID(id)
+	}
 	if choices, ok := raw["choices"].([]any); ok {
 		for i, c := range choices {
 			if choice, ok := c.(map[string]any); ok {
@@ -1552,6 +2086,9 @@ func convertResponse(data []byte, keepReasoning bool) ([]byte, error) {
 					if !keepReasoning {
 						delete(msg, "reasoning_content")
 					}
+					// Strip private Anthropic roundtrip field so it never
+					// leaks to Chat Completions consumers.
+					delete(msg, "_opencode2api_anthropic_content")
 					choice["message"] = msg
 				}
 				if v, ok := choice["logprobs"]; ok && v == nil {
@@ -1671,6 +2208,21 @@ func isFreeModel(modelID string) bool {
 func publicFacingModelID(modelID string) string {
 	if isFreeModel(modelID) {
 		return strings.TrimSuffix(modelID, "-free")
+	}
+	return modelID
+}
+
+// mapPublicToFreeModel downgrades paid model IDs to their "-free" variants for
+// keyless (public tier) requests, so deepseek-v4-flash reaches the free tier as
+// deepseek-v4-flash-free instead of failing upstream with a missing key. Keyed
+// tiers keep the exact requested model; models without a known free variant are
+// left untouched.
+func mapPublicToFreeModel(auth UpstreamAuth, modelID string) string {
+	if auth.Mode != AuthRoutePublic || isFreeModel(modelID) {
+		return modelID
+	}
+	if freeID := modelID + "-free"; modelExistsInCaches(freeID) {
+		return freeID
 	}
 	return modelID
 }
@@ -1802,7 +2354,21 @@ func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, a
 				return nil, 0, nil, readErr
 			}
 			if isAnthropicFormat(b) {
-				b = convertAnthropicToOpenAI(b, modelID)
+				converted, convErr := convertAnthropicToOpenAI(b, modelID)
+				if convErr != nil {
+					log.Info("upstream_attempt",
+						"try_model", modelID,
+						"surface", surface,
+						"status", resp.StatusCode,
+						"duration_ms", durationMs,
+						"attempt_index", attempt,
+					)
+					// Only anthropicProtocolError errors carry type/message;
+					// non-typed conversion errors stay generic so
+					// writeUpstreamError emits a safe default.
+					return nil, http.StatusBadGateway, nil, convErr
+				}
+				b = converted
 			}
 			log.Info("upstream_attempt",
 				"try_model", modelID,
@@ -1856,6 +2422,74 @@ func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, a
 		"fallback_used", false,
 	)
 	return lastBody, lastStatus, lastHeader, lastErr
+}
+
+// anthropicProtocolError is a typed error that carries Anthropic error
+// type/message through a local protocol conversion failure. Use errors.As
+// to extract it; do not parse error strings.
+type anthropicProtocolError struct {
+	errType string
+	message string
+}
+
+func (e *anthropicProtocolError) Error() string {
+	if e.errType != "" {
+		return e.errType + ": " + e.message
+	}
+	return e.message
+}
+
+// writeUpstreamError writes a protocol-shaped error response for each
+// downstream protocol (chat, claude, responses). Only local Anthropic
+// protocol conversion errors (anthropicProtocolError via errors.As) expose
+// the upstream type/message; all other errors (transport, build, etc.) get
+// a generic "upstream_error" type with a stable safe message. The error's
+// Error() string is never exposed. Invalid HTTP status (0, etc.) is
+// normalized to 502.
+func writeUpstreamError(w http.ResponseWriter, status int, err error, protocol string) {
+	if status < 100 || status >= 600 {
+		status = http.StatusBadGateway
+	}
+
+	errType := "upstream_error"
+	message := "upstream error"
+
+	var ape *anthropicProtocolError
+	if errors.As(err, &ape) {
+		if ape.errType != "" {
+			errType = ape.errType
+		}
+		if ape.message != "" {
+			message = ape.message
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	switch protocol {
+	case "claude":
+		json.NewEncoder(w).Encode(map[string]any{
+			"type": "error",
+			"error": map[string]string{
+				"type":    errType,
+				"message": message,
+			},
+		})
+	case "responses":
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"type":    errType,
+				"message": message,
+			},
+		})
+	default: // "chat"
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"type":    errType,
+				"message": message,
+			},
+		})
+	}
 }
 
 func callOpenCodeAPIStream(ctx context.Context, upstreamBody []byte, modelID string, auth UpstreamAuth) (io.ReadCloser, int, http.Header, error) {
@@ -2022,6 +2656,10 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 			req.Model = "deepseek-v4-flash-free"
 		}
 	}
+	req.Model = mapPublicToFreeModel(auth, req.Model)
+	if !validateRequestTemperature(w, req.Temperature, "chat", 0, 2) {
+		return
+	}
 
 	// 多模态路由：检测到图片时转发到配置的上游
 
@@ -2165,12 +2803,16 @@ func chatCompletionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	respBody, status, _, err := callOpenCodeAPI(r.Context(), upstreamBody, req.Model, auth)
 	if err != nil || status < 200 || status >= 300 {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		if len(respBody) > 0 {
-			w.Write(respBody)
+		if err != nil {
+			writeUpstreamError(w, status, err, "chat")
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "upstream error", "type": "upstream_error"}})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if len(respBody) > 0 {
+				w.Write(respBody)
+			} else {
+				json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "upstream error", "type": "upstream_error"}})
+			}
 		}
 		return
 	}
@@ -2408,6 +3050,49 @@ func claudeImageBlockToOpenAI(block map[string]any) (map[string]any, bool) {
 	return nil, false
 }
 
+// claudeDocumentBlockToOpenAI maps an Anthropic document content block to a
+// Chat Completions file content part. It supports source.type=base64
+// (media_type, default application/pdf) and source.type=url. A filename is
+// preserved from the block/title when available; no protocol ID is generated.
+// Returns (nil, false) when the document lacks a usable payload so the caller
+// can surface a structured 400 instead of serializing the wrapper as text.
+func claudeDocumentBlockToOpenAI(block map[string]any) (map[string]any, bool) {
+	source, _ := block["source"].(map[string]any)
+	if source == nil {
+		return nil, false
+	}
+	srcType, _ := source["type"].(string)
+	mediaType, _ := source["media_type"].(string)
+	if mediaType == "" {
+		mediaType = "application/pdf"
+	}
+	data, _ := source["data"].(string)
+	url, _ := source["url"].(string)
+
+	file := map[string]any{}
+	if filename, ok := block["filename"].(string); ok && filename != "" {
+		file["filename"] = filename
+	} else if title, ok := block["title"].(string); ok && title != "" {
+		file["filename"] = title
+	}
+
+	switch srcType {
+	case "base64":
+		if data == "" {
+			return nil, false
+		}
+		file["file_data"] = "data:" + mediaType + ";base64," + data
+		return map[string]any{"type": "file", "file": file}, true
+	case "url":
+		if url == "" {
+			return nil, false
+		}
+		file["file_data"] = url
+		return map[string]any{"type": "file", "file": file}, true
+	}
+	return nil, false
+}
+
 func extractClaudeContentText(content any) string {
 	switch c := content.(type) {
 	case string:
@@ -2453,7 +3138,7 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 			var reasoningParts []string
 			var toolCalls []ToolCall
 			var toolResults []Message
-			var followupImages []any
+			var followupAttachments []any
 			for _, item := range content {
 				block, ok := item.(map[string]any)
 				if !ok {
@@ -2467,6 +3152,10 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 					}
 				case "image":
 					if part, ok := claudeImageBlockToOpenAI(block); ok {
+						orderedContent = append(orderedContent, part)
+					}
+				case "document":
+					if part, ok := claudeDocumentBlockToOpenAI(block); ok {
 						orderedContent = append(orderedContent, part)
 					}
 				case "thinking":
@@ -2500,7 +3189,7 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 				case "tool_result":
 					toolUseID, _ := block["tool_use_id"].(string)
 					var resultText string
-					var imageParts []any
+					var attachmentParts []any // local per-block image/document parts in original order
 					switch c := block["content"].(type) {
 					case string:
 						resultText = c
@@ -2518,7 +3207,11 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 								}
 							case "image":
 								if part, ok := claudeImageBlockToOpenAI(pb); ok {
-									imageParts = append(imageParts, part)
+									attachmentParts = append(attachmentParts, part)
+								}
+							case "document":
+								if part, ok := claudeDocumentBlockToOpenAI(pb); ok {
+									attachmentParts = append(attachmentParts, part)
 								}
 							}
 						}
@@ -2529,15 +3222,28 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 							resultText = string(b)
 						}
 					}
-					if len(imageParts) > 0 {
+					// Annotate based on this block's own attachments, not a
+					// global accumulator, so parallel tool_results are labeled
+					// independently.
+					if len(attachmentParts) > 0 {
 						if resultText != "" {
 							resultText += "\n"
 						}
-						resultText += "[image attached]"
-						followupImages = append(followupImages, imageParts...)
+						var labels []string
+						for _, ap := range attachmentParts {
+							if m, ok := ap.(map[string]any); ok {
+								if m["type"] == "image_url" {
+									labels = append(labels, "[image attached]")
+								} else if m["type"] == "file" {
+									labels = append(labels, "[document attached]")
+								}
+							}
+						}
+						resultText += strings.Join(labels, "\n")
+						followupAttachments = append(followupAttachments, attachmentParts...)
 					}
 					if isError, _ := block["is_error"].(bool); isError {
-						resultText = "Error: " + resultText
+						resultText = applyErrorPrefix(resultText)
 					}
 					toolResults = append(toolResults, Message{
 						Role:       "tool",
@@ -2564,8 +3270,8 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 			// Completions' separate tool messages.
 			if msg.Role == "user" {
 				body = append(body, toolResults...)
-				if len(followupImages) > 0 {
-					body = append(body, Message{Role: "user", Content: followupImages})
+				if len(followupAttachments) > 0 {
+					body = append(body, Message{Role: "user", Content: followupAttachments})
 				}
 			}
 			if len(orderedContent) > 0 || len(reasoningParts) > 0 || len(toolCalls) > 0 || len(toolResults) == 0 {
@@ -2573,8 +3279,8 @@ func claudeToOpenAIMessages(claudeMsgs []ClaudeMessage, system any) []Message {
 			}
 			if msg.Role != "user" {
 				body = append(body, toolResults...)
-				if len(followupImages) > 0 {
-					body = append(body, Message{Role: "user", Content: followupImages})
+				if len(followupAttachments) > 0 {
+					body = append(body, Message{Role: "user", Content: followupAttachments})
 				}
 			}
 		default:
@@ -2649,6 +3355,11 @@ func countAnthropicBetas(header string) int {
 	return n
 }
 
+// countCacheControlInValue counts cache_control breakpoints on content
+// blocks within system, message content, and tool_result content arrays. It
+// recurses into all values except input_schema and tool_use input, so a
+// property named cache_control inside a schema or input object is not
+// falsely counted as a breakpoint.
 func countCacheControlInValue(v any) int {
 	switch x := v.(type) {
 	case map[string]any:
@@ -2656,7 +3367,12 @@ func countCacheControlInValue(v any) int {
 		if _, ok := x["cache_control"]; ok {
 			n++
 		}
-		for _, child := range x {
+		for key, child := range x {
+			// Skip input_schema and input — cache_control inside these is a
+			// schema/input property, not a content-block breakpoint.
+			if key == "input_schema" || key == "input" {
+				continue
+			}
 			n += countCacheControlInValue(child)
 		}
 		return n
@@ -2676,15 +3392,51 @@ func countClaudeCacheControlBlocks(req ClaudeRequest) int {
 	for _, msg := range req.Messages {
 		n += countCacheControlInValue(msg.Content)
 	}
+	// Count actual tool-level cache_control breakpoints on tool definitions,
+	// not properties named cache_control inside input_schema.
 	for _, tool := range req.Tools {
-		n += countCacheControlInValue(tool.InputSchema)
+		if tool.CacheControl != nil {
+			n++
+		}
 	}
 	return n
 }
 
+// countClaudeThinkingSignatures counts non-empty signature fields on
+// thinking content blocks at the top level of each message's content array.
+// Only actual message content blocks are counted — not nested values inside
+// tool_use input or other objects that happen to have type:"thinking" and a
+// signature key. The signature content itself is never recorded; only the
+// count is exposed in request_plan for observability. These signatures have
+// no Chat Completions equivalent and are dropped upstream.
+func countClaudeThinkingSignatures(msgs []ClaudeMessage) int {
+	var n int
+	for _, msg := range msgs {
+		blocks, ok := msg.Content.([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range blocks {
+			block, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t, _ := block["type"].(string); t == "thinking" {
+				if sig, ok := block["signature"].(string); ok && sig != "" {
+					n++
+				}
+			}
+		}
+	}
+	return n
+}
+
+// claudeUnsupportedBlockTypes lists Anthropic content block types that are
+// dropped without a structured upstream representation. document is handled
+// as a best-effort file part (see claudeDocumentBlockToOpenAI) and is not
+// listed here so it is not counted as unsupported.
 var claudeUnsupportedBlockTypes = map[string]struct{}{
 	"redacted_thinking":      {},
-	"document":               {},
 	"search_result":          {},
 	"server_tool_use":        {},
 	"web_search_tool_result": {},
@@ -2745,38 +3497,110 @@ func openAIToClaudeResponse(chatBody []byte, model string, wantReasoning bool) [
 	if len(chat.Choices) > 0 {
 		msg := chat.Choices[0].Message
 		fr := chat.Choices[0].FinishReason
-		if wantReasoning && msg.ReasoningContent != "" {
-			content = append(content, ClaudeContent{
-				Type:     "thinking",
-				Thinking: msg.ReasoningContent,
-			})
-		}
-		text := msg.Content
-		// #37635: Go gateway often puts the whole answer in reasoning_content.
-		// Promote to text when content is empty so Claude Code does not see an
-		// empty end_turn and exit the agent loop.
-		if text == "" && msg.ReasoningContent != "" && len(msg.ToolCalls) == 0 {
-			text = msg.ReasoningContent
-		}
-		if text != "" {
-			content = append(content, ClaudeContent{
-				Type: "text",
-				Text: text,
-			})
-		}
-		for _, tc := range msg.ToolCalls {
-			var input any
-			json.Unmarshal([]byte(tc.Function.Arguments), &input)
-			if input == nil {
-				input = map[string]any{}
+
+		// Try to read private ordered Anthropic content blocks first.
+		var rawMsg map[string]any
+		privateBlocks := []map[string]any(nil)
+		if json.Unmarshal(chatBody, &rawMsg) == nil {
+			if choices, ok := rawMsg["choices"].([]any); ok && len(choices) > 0 {
+				if choice, ok := choices[0].(map[string]any); ok {
+					if m, ok := choice["message"].(map[string]any); ok {
+						if pb, ok := m["_opencode2api_anthropic_content"].([]any); ok {
+							for _, item := range pb {
+								if blk, ok := item.(map[string]any); ok {
+									privateBlocks = append(privateBlocks, blk)
+								}
+							}
+						}
+					}
+				}
 			}
-			content = append(content, ClaudeContent{
-				Type:  "tool_use",
-				ID:    tc.ID,
-				Name:  tc.Function.Name,
-				Input: input,
-			})
 		}
+
+		if len(privateBlocks) > 0 {
+			// Consume private ordered blocks in array order.
+			for _, blk := range privateBlocks {
+				bt, _ := blk["type"].(string)
+				switch bt {
+				case "text":
+					text, _ := blk["text"].(string)
+					content = append(content, ClaudeContent{
+						Type: "text",
+						Text: text,
+					})
+				case "thinking":
+					if wantReasoning {
+						thinking, _ := blk["thinking"].(string)
+						cc := ClaudeContent{
+							Type:     "thinking",
+							Thinking: thinking,
+						}
+						if sig, ok := blk["signature"].(string); ok && sig != "" {
+							cc.Signature = sig
+						}
+						content = append(content, cc)
+					}
+				case "redacted_thinking":
+					if wantReasoning {
+						cc := ClaudeContent{
+							Type: "redacted_thinking",
+						}
+						if d, ok := blk["data"].(string); ok && d != "" {
+							cc.Data = d
+						}
+						content = append(content, cc)
+					}
+				case "tool_use":
+					id, _ := blk["id"].(string)
+					name, _ := blk["name"].(string)
+					input := blk["input"]
+					if input == nil {
+						input = map[string]any{}
+					}
+					content = append(content, ClaudeContent{
+						Type:  "tool_use",
+						ID:    id,
+						Name:  name,
+						Input: input,
+					})
+				}
+			}
+		} else {
+			// Fallback: string content + reasoning_content + tool_calls.
+			if wantReasoning && msg.ReasoningContent != "" {
+				content = append(content, ClaudeContent{
+					Type:     "thinking",
+					Thinking: msg.ReasoningContent,
+				})
+			}
+			text := msg.Content
+			// #37635: Go gateway often puts the whole answer in reasoning_content.
+			// Promote to text when content is empty so Claude Code does not see an
+			// empty end_turn and exit the agent loop.
+			if text == "" && msg.ReasoningContent != "" && len(msg.ToolCalls) == 0 {
+				text = msg.ReasoningContent
+			}
+			if text != "" {
+				content = append(content, ClaudeContent{
+					Type: "text",
+					Text: text,
+				})
+			}
+			for _, tc := range msg.ToolCalls {
+				var input any
+				json.Unmarshal([]byte(tc.Function.Arguments), &input)
+				if input == nil {
+					input = map[string]any{}
+				}
+				content = append(content, ClaudeContent{
+					Type:  "tool_use",
+					ID:    tc.ID,
+					Name:  tc.Function.Name,
+					Input: input,
+				})
+			}
+		}
+
 		switch fr {
 		case "stop":
 			stopReason = "end_turn"
@@ -2793,8 +3617,12 @@ func openAIToClaudeResponse(chatBody []byte, model string, wantReasoning bool) [
 		content = append(content, ClaudeContent{Type: "text", Text: ""})
 	}
 
+	// Response ID: keep upstream ID only if it is a valid msg_ ID;
+	// otherwise generate a new msg_ ID. Never leak chatcmpl/resp IDs.
+	respID := normalizeClaudeMessageID(chat.ID)
+
 	resp := ClaudeResponse{
-		ID:         fmt.Sprintf("msg_%s", randomString(24)),
+		ID:         respID,
 		Type:       "message",
 		Role:       "assistant",
 		Content:    content,
@@ -2948,6 +3776,14 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	modelIn := claudeReq.Model
 	claudeReq.Model = resolveModel(claudeReq.Model)
+	claudeReq.Model = mapPublicToFreeModel(auth, claudeReq.Model)
+	if !validateRequestTemperature(w, claudeReq.Temperature, "claude", 0, 1) {
+		return
+	}
+	if msg := validateClaudeDocumentBlocks(claudeReq.Messages); msg != "" {
+		writeProtocolValidation400(w, "claude", "", msg)
+		return
+	}
 
 	// 多模态路由
 
@@ -2981,25 +3817,26 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	systemMerged := countClaudeSystemParts(claudeReq.Messages, claudeReq.System) > 1
 	plan := map[string]any{
-		"protocol":             "claude",
-		"model_in":             modelIn,
-		"model_resolved":       chatReq.Model,
-		"auth_mode":            authModeString(auth.Mode),
-		"auth_source":          auth.Source,
-		"has_key":              auth.Token != "",
-		"upstream_surface":     upstreamSurface,
-		"stream":               claudeReq.Stream,
-		"keep_reasoning":       keepReasoning,
-		"thinking":             thinkingState(claudeReq.Thinking),
-		"reasoning_effort_in":  effortIn,
-		"reasoning_effort_out": mappedReasoningEffort(effortIn),
-		"tools_count":          len(chatReq.Tools),
-		"messages_count":       len(chatReq.Messages),
-		"system_merged":        systemMerged,
-		"context_management":   claudeReq.ContextManagement != nil,
-		"cache_control_blocks": countClaudeCacheControlBlocks(claudeReq),
-		"client_beta_count":    countAnthropicBetas(r.Header.Get("anthropic-beta")),
-		"unsupported_blocks":   scanClaudeUnsupportedBlocks(claudeReq.Messages),
+		"protocol":                "claude",
+		"model_in":                modelIn,
+		"model_resolved":          chatReq.Model,
+		"auth_mode":               authModeString(auth.Mode),
+		"auth_source":             auth.Source,
+		"has_key":                 auth.Token != "",
+		"upstream_surface":        upstreamSurface,
+		"stream":                  claudeReq.Stream,
+		"keep_reasoning":          keepReasoning,
+		"thinking":                thinkingState(claudeReq.Thinking),
+		"reasoning_effort_in":     effortIn,
+		"reasoning_effort_out":    mappedReasoningEffort(effortIn),
+		"tools_count":             len(chatReq.Tools),
+		"messages_count":          len(chatReq.Messages),
+		"system_merged":           systemMerged,
+		"context_management":      claudeReq.ContextManagement != nil,
+		"cache_control_blocks":    countClaudeCacheControlBlocks(claudeReq),
+		"history_signature_count": countClaudeThinkingSignatures(claudeReq.Messages),
+		"client_beta_count":       countAnthropicBetas(r.Header.Get("anthropic-beta")),
+		"unsupported_blocks":      scanClaudeUnsupportedBlocks(claudeReq.Messages),
 	}
 	if len(skippedServerTools) > 0 {
 		plan["skipped_server_tools"] = skippedServerTools
@@ -3027,12 +3864,16 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 
 	respBody, status, _, err := callOpenCodeAPI(r.Context(), upstreamBody, chatReq.Model, auth)
 	if err != nil || status < 200 || status >= 300 {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		if len(respBody) > 0 {
-			w.Write(respBody)
+		if err != nil {
+			writeUpstreamError(w, status, err, "claude")
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{"type": "error", "error": map[string]string{"type": "api_error", "message": "upstream error"}})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if len(respBody) > 0 {
+				w.Write(respBody)
+			} else {
+				json.NewEncoder(w).Encode(map[string]any{"type": "error", "error": map[string]string{"type": "api_error", "message": "upstream error"}})
+			}
 		}
 		return
 	}
@@ -3076,6 +3917,8 @@ func claudeMessagesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(claudeRespBody)
 }
 
+var claudeKeepaliveInterval = 15 * time.Second
+
 func claudeStreamHandler(ctx context.Context, w http.ResponseWriter, respBody io.ReadCloser, model string, keepReasoning bool) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -3100,6 +3943,40 @@ func claudeStreamHandler(ctx context.Context, w http.ResponseWriter, respBody io
 	// Accumulates reasoning when keepReasoning so we can fall back to a text
 	// block if the stream never produces content/tool_use (#37635).
 	reasoningFallback := strings.Builder{}
+
+	// --- Reader goroutine -> channel so the main loop can select on
+	// ticker/read/context without blocking, and so context cancellation
+	// unblocks the reader via Close. ---
+	type readResult struct {
+		line string
+		err  error
+	}
+	readCh := make(chan readResult)
+	readerDone := make(chan struct{})
+	readerExited := make(chan struct{})
+
+	go func() {
+		defer close(readerExited)
+		for {
+			line, err := reader.ReadString('\n')
+			select {
+			case readCh <- readResult{line: line, err: err}:
+			case <-readerDone:
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	keepaliveInterval := claudeKeepaliveInterval
+	if keepaliveInterval <= 0 {
+		keepaliveInterval = 15 * time.Second
+	}
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+
 	defer func() {
 		if len(fullUsage) > 0 {
 			pt, _ := fullUsage["prompt_tokens"].(float64)
@@ -3111,6 +3988,12 @@ func claudeStreamHandler(ctx context.Context, w http.ResponseWriter, respBody io
 		}
 		stats.toolCallCount = len(toolCallOrder)
 		stats.log(ctx, "claude")
+	}()
+	// Reader cleanup: signal goroutine, unblock any pending read, wait for exit.
+	defer func() {
+		close(readerDone)
+		respBody.Close()
+		<-readerExited
 	}()
 
 	emitClaudeEvent := func(event string, data any) {
@@ -3124,6 +4007,16 @@ func claudeStreamHandler(ctx context.Context, w http.ResponseWriter, respBody io
 		if flusher != nil {
 			flusher.Flush()
 		}
+	}
+
+	emitClaudeError := func(msg string) {
+		emitClaudeEvent("error", map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"type":    "api_error",
+				"message": msg,
+			},
+		})
 	}
 
 	closeThinkingBlock := func() {
@@ -3229,173 +4122,211 @@ func claudeStreamHandler(ctx context.Context, w http.ResponseWriter, respBody io
 		}
 	}
 
+loop:
 	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
+		select {
+		case <-ctx.Done():
+			// Client cancelled: quiet exit, no error writes.
+			return
+		case <-ticker.C:
+			// Keepalive ping — before the first upstream token this is the
+			// only thing the client receives; do NOT fake message_start.
+			emitClaudeEvent("ping", map[string]any{"type": "ping"})
+		case result := <-readCh:
+			// bufio.ReadString may return both a non-empty line and an error
+			// (e.g. the last line without a trailing newline + io.EOF). Process
+			// the line first, then handle the accompanying error via pendingErr.
+			pendingErr := result.err
+
+			line := result.line
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "data: [DONE]" || trimmed == "[DONE]" {
+				stats.doneSeen = true
+				if !finished {
+					emitClaudeError("stream ended with [DONE] but no finish_reason")
+					return
+				}
+				break loop
 			}
-			reqLogger(ctx).Error("stream read error", "error", err)
-			break
-		}
+			if strings.HasPrefix(line, "data: ") {
+				payload := line[6:]
+				if strings.TrimSpace(payload) != "" {
+					var chunk map[string]any
+					if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+						emitClaudeError("stream received malformed JSON data")
+						return
+					} else {
+						// In-band error from upstream.
+						if errVal, ok := chunk["error"]; ok && errVal != nil {
+							errMsg := "upstream stream error"
+							if errMap, ok := errVal.(map[string]any); ok {
+								if m, ok := errMap["message"].(string); ok && m != "" {
+									errMsg = m
+								}
+							} else if errStr, ok := errVal.(string); ok && errStr != "" {
+								errMsg = errStr
+							}
+							emitClaudeError(errMsg)
+							return
+						} else {
 
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "data: [DONE]" || trimmed == "[DONE]" {
-			stats.doneSeen = true
-			break
-		}
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
+							if usage, ok := chunk["usage"].(map[string]any); ok {
+								fullUsage = mergeUsageMaps(fullUsage, usage)
+							}
 
-		var chunk map[string]any
-		if err := json.Unmarshal([]byte(line[6:]), &chunk); err != nil {
-			continue
-		}
-		if usage, ok := chunk["usage"].(map[string]any); ok {
-			fullUsage = usage
-		}
+							choices, ok := chunk["choices"].([]any)
+							if !ok || len(choices) == 0 {
+								// Usage-only trailing chunk (OpenAI stream_options.include_usage).
+							} else {
+								choice, _ := choices[0].(map[string]any)
+								delta, _ := choice["delta"].(map[string]any)
+								finishReason, _ := choice["finish_reason"].(string)
+								stats.noteChunk()
 
-		choices, ok := chunk["choices"].([]any)
-		if !ok || len(choices) == 0 {
-			// Usage-only trailing chunk (OpenAI stream_options.include_usage).
-			continue
-		}
+								ensureMessageStart()
 
-		choice, _ := choices[0].(map[string]any)
-		delta, _ := choice["delta"].(map[string]any)
-		finishReason, _ := choice["finish_reason"].(string)
-		stats.noteChunk()
+								// After finish_reason, ignore further content deltas but keep reading
+								// so a later usage-only chunk can populate fullUsage.
+								if !finished {
+									if rc, ok := delta["reasoning_content"]; ok {
+										rcStr, _ := rc.(string)
+										if rcStr != "" {
+											stats.reasoningChars += len(rcStr)
+											if keepReasoning {
+												reasoningFallback.WriteString(rcStr)
+												closeTextBlock()
+												if !thinkingBlockOpen {
+													emitClaudeEvent("content_block_start", map[string]any{
+														"type":  "content_block_start",
+														"index": blockIndex,
+														"content_block": map[string]any{
+															"type":     "thinking",
+															"thinking": "",
+														},
+													})
+													thinkingBlockOpen = true
+													blockIndex++
+												}
+												emitClaudeEvent("content_block_delta", map[string]any{
+													"type":  "content_block_delta",
+													"index": blockIndex - 1,
+													"delta": map[string]any{
+														"type":     "thinking_delta",
+														"thinking": rcStr,
+													},
+												})
+											} else {
+												// Thinking not requested: promote misplaced CoT to visible text (#37635).
+												stats.promotedReasoning = true
+												emitTextDelta(rcStr)
+											}
+										}
+									}
 
-		ensureMessageStart()
+									if c, ok := delta["content"]; ok && c != nil {
+										contentStr, _ := c.(string)
+										if contentStr != "" {
+											emitTextDelta(contentStr)
+										}
+									}
 
-		// After finish_reason, ignore further content deltas but keep reading
-		// so a later usage-only chunk can populate fullUsage.
-		if finished {
-			continue
-		}
+									if rawToolCalls, ok := delta["tool_calls"].([]any); ok {
+										for _, rawTC := range rawToolCalls {
+											tc, ok := rawTC.(map[string]any)
+											if !ok {
+												continue
+											}
+											idxFloat, _ := tc["index"].(float64)
+											upstreamIndex := int(idxFloat)
 
-		if rc, ok := delta["reasoning_content"]; ok {
-			rcStr, _ := rc.(string)
-			if rcStr != "" {
-				stats.reasoningChars += len(rcStr)
-				if keepReasoning {
-					reasoningFallback.WriteString(rcStr)
-					closeTextBlock()
-					if !thinkingBlockOpen {
-						emitClaudeEvent("content_block_start", map[string]any{
-							"type":  "content_block_start",
-							"index": blockIndex,
-							"content_block": map[string]any{
-								"type":     "thinking",
-								"thinking": "",
-							},
-						})
-						thinkingBlockOpen = true
-						blockIndex++
+											closeThinkingBlock()
+											closeTextBlock()
+
+											if _, exists := toolCallAccumulator[upstreamIndex]; !exists {
+												callID, _ := tc["id"].(string)
+												if callID == "" {
+													callID = "toolu_" + randomString(12)
+												}
+												fn, _ := tc["function"].(map[string]any)
+												name, _ := fn["name"].(string)
+												toolCallAccumulator[upstreamIndex] = map[string]string{
+													"id":   callID,
+													"name": name,
+													"args": "",
+												}
+												toolCallOrder = append(toolCallOrder, upstreamIndex)
+												toolBlockIndices[upstreamIndex] = blockIndex
+												emitClaudeEvent("content_block_start", map[string]any{
+													"type":  "content_block_start",
+													"index": blockIndex,
+													"content_block": map[string]any{
+														"type":  "tool_use",
+														"id":    callID,
+														"name":  name,
+														"input": map[string]any{},
+													},
+												})
+												blockIndex++
+											}
+
+											fn, _ := tc["function"].(map[string]any)
+											if argDelta, ok := fn["arguments"].(string); ok && argDelta != "" {
+												toolCallAccumulator[upstreamIndex]["args"] += argDelta
+												emitClaudeEvent("content_block_delta", map[string]any{
+													"type":  "content_block_delta",
+													"index": toolBlockIndices[upstreamIndex],
+													"delta": map[string]any{
+														"type":         "input_json_delta",
+														"partial_json": argDelta,
+													},
+												})
+											}
+										}
+									}
+
+									if finishReason == "stop" || finishReason == "length" || finishReason == "tool_calls" || finishReason == "function_call" || finishReason == "content_filter" {
+										stats.finishReason = finishReason
+										stats.sawFinish = true
+										finished = true
+										finalizeContentBlocks()
+
+										stopReason = "end_turn"
+										switch finishReason {
+										case "length":
+											stopReason = "max_tokens"
+										case "tool_calls", "function_call":
+											stopReason = "tool_use"
+										case "content_filter":
+											stopReason = "refusal"
+										}
+										// Do not emit message_delta/stop yet: OpenAI-compatible upstreams often
+										// send the usage-only chunk after finish_reason when include_usage=true.
+									}
+								}
+							}
+						}
 					}
-					emitClaudeEvent("content_block_delta", map[string]any{
-						"type":  "content_block_delta",
-						"index": blockIndex - 1,
-						"delta": map[string]any{
-							"type":     "thinking_delta",
-							"thinking": rcStr,
-						},
-					})
-				} else {
-					// Thinking not requested: promote misplaced CoT to visible text (#37635).
-					stats.promotedReasoning = true
-					emitTextDelta(rcStr)
 				}
 			}
-		}
 
-		if c, ok := delta["content"]; ok && c != nil {
-			contentStr, _ := c.(string)
-			if contentStr != "" {
-				emitTextDelta(contentStr)
-			}
-		}
-
-		if rawToolCalls, ok := delta["tool_calls"].([]any); ok {
-			for _, rawTC := range rawToolCalls {
-				tc, ok := rawTC.(map[string]any)
-				if !ok {
-					continue
-				}
-				idxFloat, _ := tc["index"].(float64)
-				upstreamIndex := int(idxFloat)
-
-				closeThinkingBlock()
-				closeTextBlock()
-
-				if _, exists := toolCallAccumulator[upstreamIndex]; !exists {
-					callID, _ := tc["id"].(string)
-					if callID == "" {
-						callID = "toolu_" + randomString(12)
+			// Now handle a pending error from the read.
+			if pendingErr != nil {
+				if pendingErr == io.EOF {
+					if !finished {
+						emitClaudeError("stream ended without finish_reason")
+						return
 					}
-					fn, _ := tc["function"].(map[string]any)
-					name, _ := fn["name"].(string)
-					toolCallAccumulator[upstreamIndex] = map[string]string{
-						"id":   callID,
-						"name": name,
-						"args": "",
-					}
-					toolCallOrder = append(toolCallOrder, upstreamIndex)
-					toolBlockIndices[upstreamIndex] = blockIndex
-					emitClaudeEvent("content_block_start", map[string]any{
-						"type":  "content_block_start",
-						"index": blockIndex,
-						"content_block": map[string]any{
-							"type":  "tool_use",
-							"id":    callID,
-							"name":  name,
-							"input": map[string]any{},
-						},
-					})
-					blockIndex++
+					break loop
 				}
-
-				fn, _ := tc["function"].(map[string]any)
-				if argDelta, ok := fn["arguments"].(string); ok && argDelta != "" {
-					toolCallAccumulator[upstreamIndex]["args"] += argDelta
-					emitClaudeEvent("content_block_delta", map[string]any{
-						"type":  "content_block_delta",
-						"index": toolBlockIndices[upstreamIndex],
-						"delta": map[string]any{
-							"type":         "input_json_delta",
-							"partial_json": argDelta,
-						},
-					})
-				}
+				reqLogger(ctx).Error("stream read error", "error", pendingErr)
+				emitClaudeError("stream read error: " + pendingErr.Error())
+				return
 			}
-		}
-
-		if finishReason == "stop" || finishReason == "length" || finishReason == "tool_calls" || finishReason == "function_call" || finishReason == "content_filter" {
-			stats.finishReason = finishReason
-			stats.sawFinish = true
-			finished = true
-			finalizeContentBlocks()
-
-			stopReason = "end_turn"
-			switch finishReason {
-			case "length":
-				stopReason = "max_tokens"
-			case "tool_calls", "function_call":
-				stopReason = "tool_use"
-			case "content_filter":
-				stopReason = "refusal"
-			}
-			// Do not emit message_delta/stop yet: OpenAI-compatible upstreams often
-			// send the usage-only chunk after finish_reason when include_usage=true.
-			continue
 		}
 	}
 
+	// Reached only when finished is true (valid finish_reason seen).
 	ensureMessageStart()
-	if !finished {
-		finalizeContentBlocks()
-	}
 	emitClaudeEvent("message_delta", map[string]any{
 		"type":  "message_delta",
 		"delta": map[string]any{"stop_reason": stopReason},
@@ -3425,6 +4356,34 @@ func responsesInputToMessages(input any, instructions string) []Message {
 		messages = append(messages, Message{Role: "user", Content: v})
 	case []any:
 		functionOutputs := collectFunctionOutputs(v)
+		// Pre-collect call IDs present in this input array so output items
+		// whose matching call is also present are not independently appended
+		// (the call branch emits the paired tool message). Standalone outputs
+		// (e.g. previous-response-id replay) have no matching call and still
+		// append independently. Uses the same call-ID extraction rule as the
+		// call branch: call_id → id → nested tool_use.id.
+		callIDsPresent := map[string]bool{}
+		for _, item := range v {
+			elem, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch elem["type"] {
+			case "function_call", "tool_call", "apply_patch_call", "shell_call":
+				cid, _ := elem["call_id"].(string)
+				if cid == "" {
+					cid, _ = elem["id"].(string)
+				}
+				if cid == "" {
+					if tu, ok := elem["tool_use"].(map[string]any); ok {
+						cid, _ = tu["id"].(string)
+					}
+				}
+				if cid != "" {
+					callIDsPresent[cid] = true
+				}
+			}
+		}
 		for _, item := range v {
 			switch elem := item.(type) {
 			case string:
@@ -3478,8 +4437,10 @@ func responsesInputToMessages(input any, instructions string) []Message {
 						}},
 					})
 					if callID != "" {
-						output := functionOutputs[callID]
-						if output == "" {
+						// Map presence (not value=="") decides whether a payload
+						// was provided: an empty string is a legitimate output.
+						output, hasOutput := functionOutputs[callID]
+						if !hasOutput {
 							output = "[tool output missing]"
 						}
 						messages = append(messages, Message{Role: "tool", ToolCallID: callID, Content: output})
@@ -3490,25 +4451,32 @@ func responsesInputToMessages(input any, instructions string) []Message {
 						callID, _ = elem["tool_use_id"].(string)
 					}
 					if callID != "" {
-						output := functionOutputs[callID]
-						if output == "" {
-							switch o := elem["output"].(type) {
-							case string:
-								output = o
-							default:
-								if o != nil {
-									b, _ := json.Marshal(o)
-									output = string(b)
-								}
+						// If the matching call item is also present in this
+						// input array, skip independent emission — the call
+						// branch will emit the paired assistant+tool messages,
+						// preventing a leading duplicate tool message when
+						// output precedes call. Standalone outputs (no matching
+						// call, e.g. previous-response-id replay) still append
+						// independently.
+						if callIDsPresent[callID] {
+							continue
+						}
+						// Map presence (not value=="") decides whether a payload
+						// was provided: an empty string is a legitimate output.
+						output, hasOutput := functionOutputs[callID]
+						if !hasOutput {
+							// Fallback for items not collected (e.g. output
+							// field absent on a standard *_call_output). Use
+							// the single normalizer so Anthropic-style content
+							// is honored and the raw tool_result wrapper JSON
+							// is never emitted.
+							text, present := normalizeToolResultOutput(elem)
+							if present {
+								output = text
+								hasOutput = true
 							}
 						}
-						if output == "" {
-							b, err := json.Marshal(elem)
-							if err == nil {
-								output = string(b)
-							}
-						}
-						if output == "" {
+						if !hasOutput {
 							output = "[tool output missing]"
 						}
 						messages = append(messages, Message{Role: "tool", ToolCallID: callID, Content: output})
@@ -3529,6 +4497,18 @@ func responsesInputToMessages(input any, instructions string) []Message {
 					}
 					content := responsesContentToMessageContent(elem["content"])
 					messages = append(messages, Message{Role: role, Content: content})
+				case "input_file":
+					// Top-level input_file item (file upload). Map to a user
+					// message carrying a structured file part. Malformed items
+					// (no payload) are rejected earlier by the handler, so a
+					// failure here is dropped rather than serialized as text.
+					if file, ok := responsesInputFileToFile(elem); ok {
+						messages = append(messages, Message{
+							Role:    "user",
+							Content: []any{map[string]any{"type": "file", "file": file}},
+						})
+					}
+					continue
 				default:
 					role := "user"
 					if r, ok := elem["role"].(string); ok && r != "" {
@@ -3709,6 +4689,16 @@ func convertResponsesToolChoice(choice any) any {
 	return choice
 }
 
+// toolResultOutputKind marks the output item types that carry a tool/function
+// output payload. tool_result is the Anthropic-style alias accepted by the
+// Responses entrypoint in addition to the standard *_call_output types.
+var toolResultOutputKind = map[string]struct{}{
+	"function_call_output":    {},
+	"apply_patch_call_output": {},
+	"shell_call_output":       {},
+	"tool_result":             {},
+}
+
 func collectFunctionOutputs(items []any) map[string]string {
 	outputs := map[string]string{}
 	for _, item := range items {
@@ -3717,24 +4707,95 @@ func collectFunctionOutputs(items []any) map[string]string {
 			continue
 		}
 		itemType, _ := elem["type"].(string)
-		switch itemType {
-		case "function_call_output", "apply_patch_call_output", "shell_call_output":
-		default:
+		if _, ok := toolResultOutputKind[itemType]; !ok {
 			continue
 		}
+		// Standard Responses items use call_id; Anthropic-style tool_result
+		// uses tool_use_id when call_id is absent.
 		callID, _ := elem["call_id"].(string)
+		if callID == "" {
+			callID, _ = elem["tool_use_id"].(string)
+		}
 		if callID == "" {
 			continue
 		}
-		switch v := elem["output"].(type) {
-		case string:
-			outputs[callID] = v
-		default:
-			b, _ := json.Marshal(v)
-			outputs[callID] = string(b)
+		text, present := normalizeToolResultOutput(elem)
+		if present {
+			outputs[callID] = text
 		}
+		// When no payload is present, the key is left absent so the caller
+		// surfaces "[tool output missing]" — the raw wrapper JSON is never
+		// stored as the output.
 	}
 	return outputs
+}
+
+// normalizeToolResultOutput is the single helper that extracts a textual
+// output from a tool/function output item. It prefers the standard `output`
+// field; for Anthropic-style tool_result it reads `content` when `output` is
+// absent. content supports a string, a string array, or an array of
+// {type:"text"|"input_text"|"output_text", text:"..."} blocks joined by
+// newlines in original order. The boolean reports whether a payload was
+// present (an empty string is a legitimate provided output).
+func normalizeToolResultOutput(elem map[string]any) (string, bool) {
+	var text string
+	present := false
+	// Standard `output` field takes priority.
+	if v, ok := elem["output"]; ok && v != nil {
+		switch s := v.(type) {
+		case string:
+			text = s
+		default:
+			b, _ := json.Marshal(v)
+			text = string(b)
+		}
+		present = true
+	} else if c, ok := elem["content"]; ok && c != nil {
+		// Anthropic-style tool_result uses `content`.
+		text = joinToolResultContent(c)
+		present = true
+	}
+	if !present {
+		return "", false
+	}
+	// Apply is_error prefix here so the collected map already carries error
+	// semantics, independent of call/output ordering in the array.
+	if isError, _ := elem["is_error"].(bool); isError {
+		text = applyErrorPrefix(text)
+	}
+	return text, true
+}
+
+// joinToolResultContent renders an Anthropic tool_result content value to text.
+func joinToolResultContent(content any) string {
+	switch c := content.(type) {
+	case string:
+		return c
+	case []any:
+		var parts []string
+		for _, p := range c {
+			pb, ok := p.(map[string]any)
+			if !ok {
+				if s, ok := p.(string); ok {
+					parts = append(parts, s)
+				}
+				continue
+			}
+			switch pb["type"] {
+			case "text", "input_text", "output_text":
+				if t, ok := pb["text"].(string); ok {
+					parts = append(parts, t)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		if c != nil {
+			b, _ := json.Marshal(c)
+			return string(b)
+		}
+		return ""
+	}
 }
 
 func parseJSONString(input string) any {
@@ -3913,9 +4974,174 @@ func convertResponsesContentPart(part map[string]any) (map[string]any, bool) {
 			"type":      "image_url",
 			"image_url": imageURLValue,
 		}, true
+	case "input_file":
+		file, ok := responsesInputFileToFile(part)
+		if !ok {
+			return nil, false
+		}
+		return map[string]any{"type": "file", "file": file}, true
 	default:
 		return nil, false
 	}
+}
+
+// validateClaudeDocumentBlocks scans Anthropic Messages content for document
+// blocks that lack a usable source payload. It inspects top-level message
+// content blocks and nested tool_result.content blocks, but never descends
+// into tool_use input, document source, schemas, or arbitrary domain data.
+func validateClaudeDocumentBlocks(msgs []ClaudeMessage) string {
+	for _, msg := range msgs {
+		if m := validateClaudeDocumentBlocksContent(msg.Content); m != "" {
+			return m
+		}
+	}
+	return ""
+}
+
+// validateClaudeDocumentBlocksContent inspects a content array's top-level
+// blocks. For tool_result blocks, it recurses into the tool_result's own
+// content array (which may contain document blocks). It never recurses into
+// tool_use input or other arbitrary map values.
+func validateClaudeDocumentBlocksContent(content any) string {
+	blocks, ok := content.([]any)
+	if !ok {
+		return ""
+	}
+	for _, item := range blocks {
+		block, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		bt, _ := block["type"].(string)
+		if bt == "document" {
+			if _, ok := claudeDocumentBlockToOpenAI(block); !ok {
+				return "document is missing a usable source payload"
+			}
+		}
+		if bt == "tool_result" {
+			// tool_result content is itself a content array that may contain
+			// document blocks. Recurse into it, but not into any other fields.
+			if m := validateClaudeDocumentBlocksContent(block["content"]); m != "" {
+				return m
+			}
+		}
+	}
+	return ""
+}
+
+// validateResponsesFileItems scans Responses input for input_file content
+// parts that are recognized as file inputs but lack any usable payload. It
+// inspects top-level items and message content arrays only — it
+// never descends into function/tool arguments, nested tool_use.input, file
+// payload objects, metadata, or arbitrary maps. Returns a non-empty message
+// when a malformed file item is found.
+func validateResponsesFileItems(input any) string {
+	switch v := input.(type) {
+	case []any:
+		for _, item := range v {
+			if msg := validateResponsesFileItem(item); msg != "" {
+				return msg
+			}
+		}
+	}
+	return ""
+}
+
+// validateResponsesFileItem validates a single top-level input item or a
+// content part within a message content array. File validation applies only
+// to official input paths: top-level input_file items and message content
+// arrays. Output/tool_result content arrays are not validated for file
+// inputs — they use text shapes only (normalizeToolResultOutput supports
+// strings and text/input_text/output_text blocks).
+func validateResponsesFileItem(item any) string {
+	elem, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	itemType, _ := elem["type"].(string)
+	// Top-level input_file item or input_file content part.
+	if itemType == "input_file" {
+		if _, ok := responsesInputFileToFile(elem); !ok {
+			return "input_file is missing file_data, file_id, and file_url"
+		}
+		return ""
+	}
+	// For message items, recurse into the content array (content parts).
+	if itemType == "message" || itemType == "" {
+		if content, ok := elem["content"].([]any); ok {
+			for _, part := range content {
+				if msg := validateResponsesFileItem(part); msg != "" {
+					return msg
+				}
+			}
+		}
+		return ""
+	}
+	// All other item types (function_call, tool_call, tool_result,
+	// apply_patch_call, shell_call, reasoning, *_call_output, etc.) are not
+	// inspected — their arguments/input/content fields are not file inputs.
+	return ""
+}
+
+// responsesInputFileToFile extracts a Chat Completions file object from a
+// Responses input_file content part. It accepts the official common flat
+// fields (file_data, file_id, file_url, filename) as well as a nested
+// input_file object. Only known fields are selected — unknown/extension
+// fields are never copied. file_url (nested or flat) maps to Chat
+// file.file_data on a best-effort basis. Empty strings are not valid
+// payloads. The official Chat file object has only file_data/file_id/filename.
+// Returns (file, true) when a usable payload exists; (nil, false) otherwise.
+func responsesInputFileToFile(part map[string]any) (map[string]any, bool) {
+	file := map[string]any{}
+
+	// Helper: read a non-empty string from a map by key.
+	nonEmptyStr := func(m map[string]any, key string) (string, bool) {
+		if v, ok := m[key].(string); ok && v != "" {
+			return v, true
+		}
+		return "", false
+	}
+
+	// Nested input_file object: {"type":"input_file","input_file":{...}}.
+	// Only select known fields; do not wholesale-copy.
+	if nested, ok := part["input_file"].(map[string]any); ok {
+		if v, ok := nonEmptyStr(nested, "file_data"); ok {
+			file["file_data"] = v
+		}
+		if v, ok := nonEmptyStr(nested, "file_id"); ok {
+			file["file_id"] = v
+		}
+		// nested file_url maps to file.file_data (best-effort).
+		if v, ok := nonEmptyStr(nested, "file_url"); ok {
+			file["file_data"] = v
+		}
+		if v, ok := nonEmptyStr(nested, "filename"); ok {
+			file["filename"] = v
+		}
+	}
+
+	// Flat fields take priority over nested values.
+	if v, ok := nonEmptyStr(part, "file_data"); ok {
+		file["file_data"] = v
+	}
+	if v, ok := nonEmptyStr(part, "file_id"); ok {
+		file["file_id"] = v
+	}
+	// Flat file_url maps to file.file_data (best-effort).
+	if v, ok := nonEmptyStr(part, "file_url"); ok {
+		file["file_data"] = v
+	}
+	if v, ok := nonEmptyStr(part, "filename"); ok {
+		file["filename"] = v
+	}
+
+	// A usable payload requires at least one of file_data / file_id.
+	if _, hasData := file["file_data"]; !hasData {
+		if _, hasID := file["file_id"]; !hasID {
+			return nil, false
+		}
+	}
+	return file, true
 }
 
 func responsesContentToMessageContent(content any) any {
@@ -4067,6 +5293,17 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 
 	modelIn := respReq.Model
 	respReq.Model = resolveModel(respReq.Model)
+	if !validateRequestTemperature(w, respReq.Temperature, "responses", 0, 2) {
+		return
+	}
+	if msg := validateResponsesFileItems(respReq.Input); msg != "" {
+		writeProtocolValidation400(w, "responses", "input_file", msg)
+		return
+	}
+	// Note: respReq.Messages (nonstandard compatibility field) is forwarded
+	// as-is using Chat content shapes; Responses-style input_file parts are
+	// not validated or converted there. Use the official `input` field for
+	// input_file support.
 	previousState, hasPreviousState := StoredResponseState{}, false
 	if respReq.PreviousResponseID != "" {
 		previousState, hasPreviousState = loadResponseState(respReq.PreviousResponseID)
@@ -4088,6 +5325,7 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 			respReq.Model = "deepseek-v4-flash-free"
 		}
 	}
+	respReq.Model = mapPublicToFreeModel(auth, respReq.Model)
 
 	// 多模态路由
 
@@ -4236,12 +5474,16 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 
 	respBody, status, _, err := callOpenCodeAPI(r.Context(), upstreamBody, chatReq.Model, auth)
 	if err != nil || status < 200 || status >= 300 {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		if len(respBody) > 0 {
-			w.Write(respBody)
+		if err != nil {
+			writeUpstreamError(w, status, err, "responses")
 		} else {
-			json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "upstream error"}})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			if len(respBody) > 0 {
+				w.Write(respBody)
+			} else {
+				json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "upstream error"}})
+			}
 		}
 		return
 	}
@@ -4309,6 +5551,7 @@ func responsesStreamHandler(w http.ResponseWriter, r *http.Request, resp *http.R
 	terminalStatus := "completed"
 	terminalEvent := "response.completed"
 	itemStatus := "completed"
+	finished := false
 	toolCalls := map[int]map[string]any{}
 	toolOrder := []int{}
 	toolKinds := responsesToolKindMap(tools)
@@ -4316,11 +5559,43 @@ func responsesStreamHandler(w http.ResponseWriter, r *http.Request, resp *http.R
 	reasoningOutputIndex := -1
 	messageIndex := -1
 
+	// --- Reader goroutine -> channel so the main loop can select on
+	// read/context without blocking, and context cancellation unblocks the
+	// reader via Close. ---
+	type readResult struct {
+		line string
+		err  error
+	}
+	readCh := make(chan readResult)
+	readerDone := make(chan struct{})
+	readerExited := make(chan struct{})
+
+	go func() {
+		defer close(readerExited)
+		for {
+			line, err := reader.ReadString('\n')
+			select {
+			case readCh <- readResult{line: line, err: err}:
+			case <-readerDone:
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
 	defer func() {
 		stats.textChars = len(fullText)
 		stats.reasoningChars = len(fullReasoning)
 		stats.toolCallCount = len(toolOrder)
 		stats.log(ctx, "responses")
+	}()
+	// Reader cleanup: signal goroutine, unblock any pending read, wait for exit.
+	defer func() {
+		close(readerDone)
+		resp.Body.Close()
+		<-readerExited
 	}()
 
 	messageOutputIndex := func() int {
@@ -4463,257 +5738,338 @@ func responsesStreamHandler(w http.ResponseWriter, r *http.Request, resp *http.R
 		})
 	}
 
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			reqLogger(ctx).Error("stream read error", "error", err)
+	ensureCreated := func(chunk map[string]any) {
+		if createdSent {
 			return
 		}
-
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "data: [DONE]" || trimmed == "[DONE]" {
-			stats.doneSeen = true
-			break
-		}
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-
-		var chunk map[string]any
-		if err := json.Unmarshal([]byte(line[6:]), &chunk); err != nil {
-			continue
-		}
-		stats.noteChunk()
-		if !createdSent {
+		if chunk != nil {
 			if id, ok := chunk["id"].(string); ok && id != "" {
-				responseID = id
+				responseID = normalizeResponsesID(id)
 				reasoningID = "rs_" + responseID + "_0"
 				msgID = "msg_" + responseID + "_0"
 			}
 			if created, ok := chunk["created"].(float64); ok {
 				createdAt = int64(created)
 			}
-			seq++
-			emitSSEEvent(w, flusher, "response.created", map[string]any{
-				"type":            "response.created",
-				"sequence_number": seq,
-				"response":        map[string]any{"id": responseID, "object": "response", "created_at": createdAt, "status": "in_progress", "background": false, "error": nil, "output": []any{}},
-			})
-			seq++
-			emitSSEEvent(w, flusher, "response.in_progress", map[string]any{
-				"type":            "response.in_progress",
-				"sequence_number": seq,
-				"response":        map[string]any{"id": responseID, "object": "response", "created_at": createdAt, "status": "in_progress"},
-			})
-			createdSent = true
 		}
-		choices, ok := chunk["choices"].([]any)
-		if !ok || len(choices) == 0 {
-			if usage, ok := chunk["usage"].(map[string]any); ok {
-				totalUsage = usage
-			}
-			continue
-		}
+		seq++
+		emitSSEEvent(w, flusher, "response.created", map[string]any{
+			"type":            "response.created",
+			"sequence_number": seq,
+			"response":        map[string]any{"id": responseID, "object": "response", "created_at": createdAt, "status": "in_progress", "background": false, "error": nil, "output": []any{}},
+		})
+		seq++
+		emitSSEEvent(w, flusher, "response.in_progress", map[string]any{
+			"type":            "response.in_progress",
+			"sequence_number": seq,
+			"response":        map[string]any{"id": responseID, "object": "response", "created_at": createdAt, "status": "in_progress"},
+		})
+		createdSent = true
+	}
 
-		choice, _ := choices[0].(map[string]any)
-		delta, _ := choice["delta"].(map[string]any)
-		finishReason, _ := choice["finish_reason"].(string)
-		if finishReason != "" {
-			stats.finishReason = finishReason
-			stats.sawFinish = true
+	emitResponseFailed := func(msg string) {
+		ensureCreated(nil)
+		failedResponse := map[string]any{
+			"id":         responseID,
+			"object":     "response",
+			"created_at": createdAt,
+			"status":     "failed",
+			"background": false,
+			"error": map[string]any{
+				"code":    "server_error",
+				"message": msg,
+			},
+			"incomplete_details": nil,
+			"model":              model,
+			"output":             []any{},
 		}
+		applyResponsesRequestEcho(failedResponse, originalReq)
+		seq++
+		emitSSEEvent(w, flusher, "response.failed", map[string]any{
+			"type":            "response.failed",
+			"sequence_number": seq,
+			"response":        failedResponse,
+		})
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
 
-		if rc, ok := delta["reasoning_content"]; ok && wantReasoning {
-			rcStr, _ := rc.(string)
-			if rcStr != "" {
-				if !reasoningStarted {
-					reasoningOutputIndex = indexAllocator.Allocate()
-					seq++
-					emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
-						"type":            "response.output_item.added",
-						"sequence_number": seq,
-						"output_index":    reasoningOutputIndex,
-						"item":            reasoningItem("in_progress"),
-					})
-					seq++
-					emitSSEEvent(w, flusher, "response.reasoning_summary_part.added", map[string]any{
-						"type":            "response.reasoning_summary_part.added",
-						"sequence_number": seq,
-						"item_id":         reasoningID,
-						"output_index":    reasoningOutputIndex,
-						"summary_index":   0,
-						"part":            map[string]any{"type": "summary_text", "text": ""},
-					})
-					reasoningStarted = true
-				}
-				fullReasoning += rcStr
-				seq++
-				emitSSEEvent(w, flusher, "response.reasoning_summary_text.delta", map[string]any{
-					"type":            "response.reasoning_summary_text.delta",
-					"sequence_number": seq,
-					"item_id":         reasoningID,
-					"output_index":    reasoningOutputIndex,
-					"summary_index":   0,
-					"delta":           rcStr,
-				})
-			}
-		}
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			// Client cancelled: quiet exit, no error writes.
+			return
+		case result := <-readCh:
+			// bufio.ReadString may return both a non-empty line and an error
+			// (e.g. the last line without a trailing newline + io.EOF). Process
+			// the line first, then handle the accompanying error via pendingErr.
+			pendingErr := result.err
 
-		contentStr := ""
-		if c, ok := delta["content"]; ok && c != nil {
-			contentStr, _ = c.(string)
-		}
-		// #37635: when thinking is not kept, promote misplaced reasoning to visible text.
-		if contentStr == "" && !wantReasoning {
-			if rc, ok := delta["reasoning_content"].(string); ok {
-				if rc != "" {
-					stats.promotedReasoning = true
+			line := result.line
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "data: [DONE]" || trimmed == "[DONE]" {
+				stats.doneSeen = true
+				if !finished {
+					emitResponseFailed("stream ended with [DONE] but no finish_reason")
+					return
 				}
-				contentStr = rc
+				break loop
 			}
-		}
-		if contentStr != "" {
-			// The terminal finish reason determines the item's final status. Keep the
-			// reasoning item open until that reason is known so a truncation cannot
-			// first announce it as completed.
-			if !messageStarted {
-				idx := messageOutputIndex()
-				seq++
-				emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
-					"type":            "response.output_item.added",
-					"sequence_number": seq,
-					"output_index":    idx,
-					"item":            map[string]any{"id": msgID, "type": "message", "status": "in_progress", "content": []any{}, "role": "assistant"},
-				})
-				seq++
-				emitSSEEvent(w, flusher, "response.content_part.added", map[string]any{
-					"type":            "response.content_part.added",
-					"sequence_number": seq,
-					"item_id":         msgID,
-					"output_index":    idx,
-					"content_index":   0,
-					"part":            map[string]any{"type": "output_text", "annotations": []any{}, "logprobs": []any{}, "text": ""},
-				})
-				messageStarted = true
-			}
-			fullText += contentStr
-			seq++
-			emitSSEEvent(w, flusher, "response.output_text.delta", map[string]any{
-				"type":            "response.output_text.delta",
-				"sequence_number": seq,
-				"item_id":         msgID,
-				"output_index":    messageOutputIndex(),
-				"content_index":   0,
-				"delta":           contentStr,
-				"logprobs":        []any{},
-			})
-		}
+			if strings.HasPrefix(line, "data: ") {
+				payload := line[6:]
+				if strings.TrimSpace(payload) != "" {
+					var chunk map[string]any
+					if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+						emitResponseFailed("stream received malformed JSON data")
+						return
+					} else {
+						// In-band error from upstream.
+						if errVal, ok := chunk["error"]; ok && errVal != nil {
+							errMsg := "upstream stream error"
+							if errMap, ok := errVal.(map[string]any); ok {
+								if m, ok := errMap["message"].(string); ok && m != "" {
+									errMsg = m
+								}
+							} else if errStr, ok := errVal.(string); ok && errStr != "" {
+								errMsg = errStr
+							}
+							emitResponseFailed(errMsg)
+							return
+						} else {
+							stats.noteChunk()
+							ensureCreated(chunk)
+							choices, ok := chunk["choices"].([]any)
+							if !ok || len(choices) == 0 {
+								if usage, ok := chunk["usage"].(map[string]any); ok {
+									totalUsage = usage
+								}
+							} else {
+								choice, _ := choices[0].(map[string]any)
+								delta, _ := choice["delta"].(map[string]any)
+								finishReason, _ := choice["finish_reason"].(string)
+								if finishReason != "" {
+									stats.finishReason = finishReason
+									stats.sawFinish = true
+								}
 
-		rawToolCalls, _ := delta["tool_calls"].([]any)
-		for _, rawToolCall := range rawToolCalls {
-			tc, ok := rawToolCall.(map[string]any)
-			if !ok {
-				continue
-			}
-			idxFloat, _ := tc["index"].(float64)
-			upstreamIndex := int(idxFloat)
-			call, exists := toolCalls[upstreamIndex]
-			if !exists {
-				outputIndex := indexAllocator.Allocate()
-				callID, _ := tc["id"].(string)
-				if callID == "" {
-					callID = "call_" + randomString(12)
-				}
-				fn, _ := tc["function"].(map[string]any)
-				name, _ := fn["name"].(string)
-				itemType := toolCallOutputType(name, toolKinds)
-				call = map[string]any{
-					"output_index": outputIndex,
-					"item_id":      "fc_" + callID,
-					"call_id":      callID,
-					"name":         name,
-					"arguments":    "",
-					"done":         false,
-					"item_type":    itemType,
-				}
-				toolCalls[upstreamIndex] = call
-				toolOrder = append(toolOrder, upstreamIndex)
-				seq++
-				emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
-					"type":            "response.output_item.added",
-					"sequence_number": seq,
-					"output_index":    outputIndex,
-					"item": map[string]any{
-						"id":        call["item_id"],
-						"type":      itemType,
-						"status":    "in_progress",
-						"arguments": "",
-						"call_id":   callID,
-						"name":      name,
-					},
-				})
-			}
-			fn, _ := tc["function"].(map[string]any)
-			if name, _ := fn["name"].(string); name != "" {
-				call["name"] = name
-				if call["item_type"] == "function_call" {
-					call["item_type"] = toolCallOutputType(name, toolKinds)
-				}
-			}
-			if argDelta, _ := fn["arguments"].(string); argDelta != "" {
-				call["arguments"] = call["arguments"].(string) + argDelta
-				seq++
-				emitSSEEvent(w, flusher, "response.function_call_arguments.delta", map[string]any{
-					"type":            "response.function_call_arguments.delta",
-					"sequence_number": seq,
-					"item_id":         call["item_id"],
-					"output_index":    call["output_index"],
-					"delta":           argDelta,
-				})
-			}
-		}
+								if !finished {
+									if rc, ok := delta["reasoning_content"]; ok && wantReasoning {
+										rcStr, _ := rc.(string)
+										if rcStr != "" {
+											if !reasoningStarted {
+												reasoningOutputIndex = indexAllocator.Allocate()
+												seq++
+												emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
+													"type":            "response.output_item.added",
+													"sequence_number": seq,
+													"output_index":    reasoningOutputIndex,
+													"item":            reasoningItem("in_progress"),
+												})
+												seq++
+												emitSSEEvent(w, flusher, "response.reasoning_summary_part.added", map[string]any{
+													"type":            "response.reasoning_summary_part.added",
+													"sequence_number": seq,
+													"item_id":         reasoningID,
+													"output_index":    reasoningOutputIndex,
+													"summary_index":   0,
+													"part":            map[string]any{"type": "summary_text", "text": ""},
+												})
+												reasoningStarted = true
+											}
+											fullReasoning += rcStr
+											seq++
+											emitSSEEvent(w, flusher, "response.reasoning_summary_text.delta", map[string]any{
+												"type":            "response.reasoning_summary_text.delta",
+												"sequence_number": seq,
+												"item_id":         reasoningID,
+												"output_index":    reasoningOutputIndex,
+												"summary_index":   0,
+												"delta":           rcStr,
+											})
+										}
+									}
 
-		if usage, ok := chunk["usage"].(map[string]any); ok {
-			totalUsage = usage
-		}
-		if finishReason == "stop" || finishReason == "length" || finishReason == "content_filter" {
-			if finishReason == "length" {
-				terminalStatus = "incomplete"
-				terminalEvent = "response.incomplete"
-				itemStatus = "incomplete"
+									contentStr := ""
+									if c, ok := delta["content"]; ok && c != nil {
+										contentStr, _ = c.(string)
+									}
+									// #37635: when thinking is not kept, promote misplaced reasoning to visible text.
+									if contentStr == "" && !wantReasoning {
+										if rc, ok := delta["reasoning_content"].(string); ok {
+											if rc != "" {
+												stats.promotedReasoning = true
+											}
+											contentStr = rc
+										}
+									}
+									if contentStr != "" {
+										// The terminal finish reason determines the item's final status. Keep the
+										// reasoning item open until that reason is known so a truncation cannot
+										// first announce it as completed.
+										if !messageStarted {
+											idx := messageOutputIndex()
+											seq++
+											emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
+												"type":            "response.output_item.added",
+												"sequence_number": seq,
+												"output_index":    idx,
+												"item":            map[string]any{"id": msgID, "type": "message", "status": "in_progress", "content": []any{}, "role": "assistant"},
+											})
+											seq++
+											emitSSEEvent(w, flusher, "response.content_part.added", map[string]any{
+												"type":            "response.content_part.added",
+												"sequence_number": seq,
+												"item_id":         msgID,
+												"output_index":    idx,
+												"content_index":   0,
+												"part":            map[string]any{"type": "output_text", "annotations": []any{}, "logprobs": []any{}, "text": ""},
+											})
+											messageStarted = true
+										}
+										fullText += contentStr
+										seq++
+										emitSSEEvent(w, flusher, "response.output_text.delta", map[string]any{
+											"type":            "response.output_text.delta",
+											"sequence_number": seq,
+											"item_id":         msgID,
+											"output_index":    messageOutputIndex(),
+											"content_index":   0,
+											"delta":           contentStr,
+											"logprobs":        []any{},
+										})
+									}
+
+									rawToolCalls, _ := delta["tool_calls"].([]any)
+									for _, rawToolCall := range rawToolCalls {
+										tc, ok := rawToolCall.(map[string]any)
+										if !ok {
+											continue
+										}
+										idxFloat, _ := tc["index"].(float64)
+										upstreamIndex := int(idxFloat)
+										call, exists := toolCalls[upstreamIndex]
+										if !exists {
+											outputIndex := indexAllocator.Allocate()
+											callID, _ := tc["id"].(string)
+											if callID == "" {
+												callID = "call_" + randomString(12)
+											}
+											fn, _ := tc["function"].(map[string]any)
+											name, _ := fn["name"].(string)
+											itemType := toolCallOutputType(name, toolKinds)
+											call = map[string]any{
+												"output_index": outputIndex,
+												"item_id":      "fc_" + callID,
+												"call_id":      callID,
+												"name":         name,
+												"arguments":    "",
+												"done":         false,
+												"item_type":    itemType,
+											}
+											toolCalls[upstreamIndex] = call
+											toolOrder = append(toolOrder, upstreamIndex)
+											seq++
+											emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
+												"type":            "response.output_item.added",
+												"sequence_number": seq,
+												"output_index":    outputIndex,
+												"item": map[string]any{
+													"id":        call["item_id"],
+													"type":      itemType,
+													"status":    "in_progress",
+													"arguments": "",
+													"call_id":   callID,
+													"name":      name,
+												},
+											})
+										}
+										fn, _ := tc["function"].(map[string]any)
+										if name, _ := fn["name"].(string); name != "" {
+											call["name"] = name
+											if call["item_type"] == "function_call" {
+												call["item_type"] = toolCallOutputType(name, toolKinds)
+											}
+										}
+										if argDelta, _ := fn["arguments"].(string); argDelta != "" {
+											call["arguments"] = call["arguments"].(string) + argDelta
+											seq++
+											emitSSEEvent(w, flusher, "response.function_call_arguments.delta", map[string]any{
+												"type":            "response.function_call_arguments.delta",
+												"sequence_number": seq,
+												"item_id":         call["item_id"],
+												"output_index":    call["output_index"],
+												"delta":           argDelta,
+											})
+										}
+									}
+
+									if usage, ok := chunk["usage"].(map[string]any); ok {
+										totalUsage = usage
+									}
+									if finishReason == "stop" || finishReason == "length" || finishReason == "tool_calls" || finishReason == "function_call" || finishReason == "content_filter" {
+										finished = true
+										if finishReason == "length" {
+											terminalStatus = "incomplete"
+											terminalEvent = "response.incomplete"
+											itemStatus = "incomplete"
+										}
+										// Do not emit done events yet: a trailing error
+										// must still produce response.failed without any
+										// status=completed item.done. Done events are
+										// emitted only after the loop exits cleanly.
+									}
+								} else {
+									// After finish_reason, only look for usage-only trailing chunks.
+									if usage, ok := chunk["usage"].(map[string]any); ok {
+										totalUsage = usage
+									}
+								}
+							}
+						}
+					}
+				}
 			}
-			emitReasoningDone()
-			if !messageStarted && len(toolCalls) == 0 {
-				idx := messageOutputIndex()
-				seq++
-				emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
-					"type":            "response.output_item.added",
-					"sequence_number": seq,
-					"output_index":    idx,
-					"item":            map[string]any{"id": msgID, "type": "message", "status": "in_progress", "content": []any{}, "role": "assistant"},
-				})
-				seq++
-				emitSSEEvent(w, flusher, "response.content_part.added", map[string]any{
-					"type":            "response.content_part.added",
-					"sequence_number": seq,
-					"item_id":         msgID,
-					"output_index":    idx,
-					"content_index":   0,
-					"part":            map[string]any{"type": "output_text", "annotations": []any{}, "logprobs": []any{}, "text": ""},
-				})
-				messageStarted = true
-			}
-			emitMessageDone()
-			for _, idx := range toolOrder {
-				emitToolCallDone(toolCalls[idx]["output_index"].(int), toolCalls[idx])
+
+			// Now handle a pending error from the read.
+			if pendingErr != nil {
+				if pendingErr == io.EOF {
+					if !finished {
+						emitResponseFailed("stream ended without finish_reason")
+						return
+					}
+					break loop
+				}
+				reqLogger(ctx).Error("stream read error", "error", pendingErr)
+				emitResponseFailed("stream read error: " + pendingErr.Error())
+				return
 			}
 		}
 	}
 
+	// Reached only when finished is true.
 	emitReasoningDone()
+	if !messageStarted && len(toolCalls) == 0 {
+		idx := messageOutputIndex()
+		seq++
+		emitSSEEvent(w, flusher, "response.output_item.added", map[string]any{
+			"type":            "response.output_item.added",
+			"sequence_number": seq,
+			"output_index":    idx,
+			"item":            map[string]any{"id": msgID, "type": "message", "status": "in_progress", "content": []any{}, "role": "assistant"},
+		})
+		seq++
+		emitSSEEvent(w, flusher, "response.content_part.added", map[string]any{
+			"type":            "response.content_part.added",
+			"sequence_number": seq,
+			"item_id":         msgID,
+			"output_index":    idx,
+			"content_index":   0,
+			"part":            map[string]any{"type": "output_text", "annotations": []any{}, "logprobs": []any{}, "text": ""},
+		})
+		messageStarted = true
+	}
 	emitMessageDone()
 	for _, idx := range toolOrder {
 		emitToolCallDone(toolCalls[idx]["output_index"].(int), toolCalls[idx])
@@ -4857,8 +6213,9 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 
 	outcome := responsesOutcome(finishReason)
 	status := outcome.Status
+	normalizedID := normalizeResponsesID(chat.ID)
 	responses := map[string]any{
-		"id":                 chat.ID,
+		"id":                 normalizedID,
 		"object":             "response",
 		"status":             status,
 		"background":         false,
@@ -4873,11 +6230,11 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 	if toolChoice != nil {
 		responses["tool_choice"] = toolChoice
 	}
-	outputID := "msg_" + chat.ID + "_0"
+	outputID := "msg_" + normalizedID + "_0"
 	output := []any{}
 	if reasoning != "" {
 		output = append(output, map[string]any{
-			"id":                "rs_" + chat.ID,
+			"id":                "rs_" + normalizedID,
 			"type":              "reasoning",
 			"encrypted_content": "",
 			"summary":           []any{map[string]any{"type": "summary_text", "text": reasoning}},

--- a/main_test.go
+++ b/main_test.go
@@ -755,6 +755,42 @@ func TestResolveModelMapsStrippedFreeNameBackToUpstream(t *testing.T) {
 	}
 }
 
+func TestMapPublicToFreeModel(t *testing.T) {
+	oldModelsCache := modelsCache
+	oldGoModelsCache := goModelsCache
+	modelMu.Lock()
+	modelsCache = []ModelInfo{{ID: "deepseek-v4-flash"}, {ID: "deepseek-v4-flash-free"}, {ID: "mimo-v2.5-free"}}
+	goModelsCache = nil
+	modelMu.Unlock()
+	t.Cleanup(func() {
+		modelMu.Lock()
+		modelsCache = oldModelsCache
+		goModelsCache = oldGoModelsCache
+		modelMu.Unlock()
+	})
+
+	public := UpstreamAuth{Mode: AuthRoutePublic}
+	keyed := UpstreamAuth{Mode: AuthRouteAuto, Token: "sk-validkey0123456789abcdef"}
+
+	tests := []struct {
+		name  string
+		auth  UpstreamAuth
+		model string
+		want  string
+	}{
+		{"public paid with free variant maps to free", public, "deepseek-v4-flash", "deepseek-v4-flash-free"},
+		{"public free model stays", public, "deepseek-v4-flash-free", "deepseek-v4-flash-free"},
+		{"public model without free variant stays", public, "laguna-s-2.1", "laguna-s-2.1"},
+		{"keyed paid model stays", keyed, "deepseek-v4-flash", "deepseek-v4-flash"},
+		{"empty model stays", public, "", ""},
+	}
+	for _, tt := range tests {
+		if got := mapPublicToFreeModel(tt.auth, tt.model); got != tt.want {
+			t.Errorf("%s: mapPublicToFreeModel(%v, %q) = %q, want %q", tt.name, tt.auth.Mode, tt.model, got, tt.want)
+		}
+	}
+}
+
 func TestExtractUpstreamAuthKeyValidation(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/max_tokens_cap_test.go
+++ b/max_tokens_cap_test.go
@@ -1,0 +1,135 @@
+package main
+
+import "testing"
+
+func TestMaxTokensCapGlobal(t *testing.T) {
+	// Set up global cap
+	configMu.Lock()
+	origGlobal := maxTokensCap
+	origPerModel := maxTokensCapPerModel
+	maxTokensCap = 131072
+	maxTokensCapPerModel = nil
+	configMu.Unlock()
+	t.Cleanup(func() {
+		configMu.Lock()
+		maxTokensCap = origGlobal
+		maxTokensCapPerModel = origPerModel
+		configMu.Unlock()
+	})
+
+	tests := []struct {
+		name      string
+		maxTokens int
+		want      int
+	}{
+		{"below cap", 1000, 1000},
+		{"exactly cap", 131072, 131072},
+		{"above cap", 200000, 131072},
+		{"far above cap", 1000000, 131072},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &OpenAIRequest{Model: "test-model", MaxTokens: ptr(tt.maxTokens)}
+			body := convertRequest(req)
+			got, ok := body["max_tokens"].(int)
+			if !ok {
+				t.Fatalf("max_tokens not int: %#v", body["max_tokens"])
+			}
+			if got != tt.want {
+				t.Fatalf("max_tokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxTokensCapPerModel(t *testing.T) {
+	configMu.Lock()
+	origGlobal := maxTokensCap
+	origPerModel := maxTokensCapPerModel
+	maxTokensCap = 131072
+	maxTokensCapPerModel = map[string]int{
+		"model-a": 50000,
+		"model-b": 0, // 0 = no cap for this model
+	}
+	configMu.Unlock()
+	t.Cleanup(func() {
+		configMu.Lock()
+		maxTokensCap = origGlobal
+		maxTokensCapPerModel = origPerModel
+		configMu.Unlock()
+	})
+
+	tests := []struct {
+		name      string
+		model     string
+		maxTokens int
+		want      int
+	}{
+		{"per-model cap applies", "model-a", 100000, 50000},
+		{"per-model cap exact", "model-a", 50000, 50000},
+		{"per-model cap below", "model-a", 100, 100},
+		{"per-model zero disables cap", "model-b", 999999, 999999},
+		{"falls back to global", "model-c", 200000, 131072},
+		{"global cap below", "model-c", 100, 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &OpenAIRequest{Model: tt.model, MaxTokens: ptr(tt.maxTokens)}
+			body := convertRequest(req)
+			got, ok := body["max_tokens"].(int)
+			if !ok {
+				t.Fatalf("max_tokens not int: %#v", body["max_tokens"])
+			}
+			if got != tt.want {
+				t.Fatalf("max_tokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxTokensCapNoCapWhenZero(t *testing.T) {
+	configMu.Lock()
+	origGlobal := maxTokensCap
+	origPerModel := maxTokensCapPerModel
+	maxTokensCap = 0
+	maxTokensCapPerModel = nil
+	configMu.Unlock()
+	t.Cleanup(func() {
+		configMu.Lock()
+		maxTokensCap = origGlobal
+		maxTokensCapPerModel = origPerModel
+		configMu.Unlock()
+	})
+
+	req := &OpenAIRequest{Model: "any-model", MaxTokens: ptr(9999999)}
+	body := convertRequest(req)
+	got, ok := body["max_tokens"].(int)
+	if !ok {
+		t.Fatalf("max_tokens not int: %#v", body["max_tokens"])
+	}
+	if got != 9999999 {
+		t.Fatalf("max_tokens = %d, want 9999999 (no cap)", got)
+	}
+}
+
+func TestMaxTokensCapNilMaxTokens(t *testing.T) {
+	configMu.Lock()
+	origGlobal := maxTokensCap
+	origPerModel := maxTokensCapPerModel
+	maxTokensCap = 131072
+	maxTokensCapPerModel = nil
+	configMu.Unlock()
+	t.Cleanup(func() {
+		configMu.Lock()
+		maxTokensCap = origGlobal
+		maxTokensCapPerModel = origPerModel
+		configMu.Unlock()
+	})
+
+	// When max_tokens is not set, it should not appear in the converted request
+	req := &OpenAIRequest{Model: "any-model", MaxTokens: nil}
+	body := convertRequest(req)
+	if _, exists := body["max_tokens"]; exists {
+		t.Fatalf("max_tokens should not be set when nil")
+	}
+}

--- a/request_compatibility_test.go
+++ b/request_compatibility_test.go
@@ -1,0 +1,2043 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// =====================================================================
+// Part A: /v1/responses Anthropic-style tool_result compatibility
+// =====================================================================
+
+// TestResponsesToolResult_AnthropicStyleContentBlocks verifies that a
+// Responses tool_result with Anthropic-style content blocks (string, string
+// array, and typed text blocks) is normalized into a single tool message and
+// the raw wrapper JSON is never emitted to the upstream.
+func TestResponsesToolResult_AnthropicStyleContentBlocks(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_1","name":"search","arguments":"{\"q\":\"x\"}"},
+			{"type":"tool_result","call_id":"call_1","content":[
+				{"type":"text","text":"line one"},
+				{"type":"text","text":"line two"}
+			]},
+			{"type":"function_call","call_id":"call_2","name":"calc","arguments":"{}"},
+			{"type":"tool_result","tool_use_id":"call_2","content":["raw string a","raw string b"]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("payload count = %d", len(transport.requestPayloads))
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Expect: assistant(call_1), tool(call_1), assistant(call_2), tool(call_2)
+	if len(messages) != 4 {
+		t.Fatalf("messages = %#v", messages)
+	}
+	// tool message for call_1
+	tool1, _ := messages[1].(map[string]any)
+	if tool1["role"] != "tool" {
+		t.Fatalf("tool1 role = %#v", tool1["role"])
+	}
+	if tool1["tool_call_id"] != "call_1" {
+		t.Fatalf("tool1 tool_call_id = %#v", tool1["tool_call_id"])
+	}
+	if got := tool1["content"]; got != "line one\nline two" {
+		t.Fatalf("tool1 content = %#v, want joined blocks", got)
+	}
+	// tool message for call_2 uses tool_use_id alias
+	tool2, _ := messages[3].(map[string]any)
+	if tool2["tool_call_id"] != "call_2" {
+		t.Fatalf("tool2 tool_call_id = %#v", tool2["tool_call_id"])
+	}
+	if got := tool2["content"]; got != "raw string a\nraw string b" {
+		t.Fatalf("tool2 content = %#v, want joined string array", got)
+	}
+	// No raw wrapper JSON should appear in any tool content.
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if c, ok := mm["content"].(string); ok {
+			if strings.Contains(c, `"type":"tool_result"`) {
+				t.Fatalf("raw tool_result wrapper JSON leaked: %s", c)
+			}
+		}
+	}
+}
+
+// TestResponsesToolResult_IsErrorPrefix verifies is_error:true adds the stable
+// "Error: " prefix without duplication.
+func TestResponsesToolResult_IsErrorPrefix(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_err","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_err","is_error":true,"content":"boom"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	tool, _ := messages[1].(map[string]any)
+	if got := tool["content"]; got != "Error: boom" {
+		t.Fatalf("is_error content = %#v, want 'Error: boom'", got)
+	}
+}
+
+// TestResponsesToolResult_EmptyStringIsLegitimateOutput verifies that an
+// empty string content is treated as a provided output (not missing).
+func TestResponsesToolResult_EmptyStringIsLegitimateOutput(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_empty","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_empty","content":""}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	tool, _ := messages[1].(map[string]any)
+	if got, ok := tool["content"]; !ok || got != "" {
+		t.Fatalf("empty content = %#v (ok=%v), want empty string present", got, ok)
+	}
+}
+
+// TestResponsesToolResult_StandardOutputFieldStillWorks verifies the standard
+// function_call_output output field still maps correctly.
+func TestResponsesToolResult_StandardOutputFieldStillWorks(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_std","name":"f","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_std","output":"standard result"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	tool, _ := messages[1].(map[string]any)
+	if got := tool["content"]; got != "standard result" {
+		t.Fatalf("standard output = %#v", got)
+	}
+}
+
+// TestResponsesToolResult_NoDuplicateToolMessages verifies fixToolCallGaps does
+// not produce duplicate tool messages when call+output are already paired.
+func TestResponsesToolResult_NoDuplicateToolMessages(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_dup","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_dup","content":"result"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	toolCount := 0
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" {
+			toolCount++
+		}
+	}
+	if toolCount != 1 {
+		t.Fatalf("tool message count = %d, want 1 (no duplicates)", toolCount)
+	}
+}
+
+// =====================================================================
+// Part B: document / input_file structured file parts
+// =====================================================================
+
+func okChatBody() string {
+	return `{"id":"r","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
+}
+
+// TestClaudeDocument_Base64 verifies a base64 document maps to a file part.
+func TestClaudeDocument_Base64(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"user","content":[
+			{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}},
+			{"type":"text","text":"summarize this pdf"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// [0]=user with content array
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("content len = %d", len(content))
+	}
+	filePart, _ := content[0].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("file part type = %#v", filePart["type"])
+	}
+	file, _ := filePart["file"].(map[string]any)
+	data, _ := file["file_data"].(string)
+	if !strings.HasPrefix(data, "data:application/pdf;base64,JVBERi0=") {
+		t.Fatalf("file_data = %#v", data)
+	}
+	// text part preserved in order
+	textPart, _ := content[1].(map[string]any)
+	if textPart["type"] != "text" || textPart["text"] != "summarize this pdf" {
+		t.Fatalf("text part = %#v", textPart)
+	}
+}
+
+// TestClaudeDocument_URL verifies a URL document maps to a file part.
+func TestClaudeDocument_URL(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"user","content":[
+			{"type":"document","source":{"type":"url","url":"https://example.test/doc.pdf"}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("file part type = %#v", filePart["type"])
+	}
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_data"]; got != "https://example.test/doc.pdf" {
+		t.Fatalf("file_data = %#v", got)
+	}
+}
+
+// TestClaudeDocument_InToolResult verifies document inside tool_result becomes
+// a followup user attachment, not silently dropped.
+func TestClaudeDocument_InToolResult(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_doc","name":"get_doc","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_doc","content":[
+				{"type":"text","text":"here is the doc"},
+				{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}}
+			]}]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Expect: assistant(tool_use), tool(result text), user(document attachment)
+	if len(messages) < 3 {
+		t.Fatalf("messages = %#v", messages)
+	}
+	follow, _ := messages[2].(map[string]any)
+	if follow["role"] != "user" {
+		t.Fatalf("followup role = %#v", follow["role"])
+	}
+	parts, _ := follow["content"].([]any)
+	if len(parts) != 1 {
+		t.Fatalf("followup parts = %#v", parts)
+	}
+	filePart, _ := parts[0].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("followup file type = %#v", filePart["type"])
+	}
+	// tool text should mention document attached
+	tool, _ := messages[1].(map[string]any)
+	if c, _ := tool["content"].(string); !strings.Contains(c, "[document attached]") {
+		t.Fatalf("tool content missing document marker: %q", c)
+	}
+}
+
+// TestClaudeDocument_MalformedReturns400 verifies a document without payload
+// returns a protocol-shaped 400, not text serialization.
+func TestClaudeDocument_MalformedReturns400(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"user","content":[
+			{"type":"document","source":{"type":"base64","data":""}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %s", ct)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["type"] != "invalid_request_error" {
+		t.Fatalf("error.type = %#v", errObj["type"])
+	}
+}
+
+// TestResponsesInputFile_FlatFileData verifies flat file_data field.
+func TestResponsesInputFile_FlatFileData(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_text","text":"analyze this"},
+			{"type":"input_file","file_data":"data:application/pdf;base64,JVBERi0=","filename":"doc.pdf"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("content len = %d", len(content))
+	}
+	filePart, _ := content[1].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("file part type = %#v", filePart["type"])
+	}
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_data"]; got != "data:application/pdf;base64,JVBERi0=" {
+		t.Fatalf("file_data = %#v", got)
+	}
+	if got := file["filename"]; got != "doc.pdf" {
+		t.Fatalf("filename = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_FileID verifies file_id field.
+func TestResponsesInputFile_FileID(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","file_id":"file-abc123"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("file part type = %#v", filePart["type"])
+	}
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_id"]; got != "file-abc123" {
+		t.Fatalf("file_id = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_FileURL verifies file_url maps to file_data.
+func TestResponsesInputFile_FileURL(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","file_url":"https://example.test/file.pdf"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_data"]; got != "https://example.test/file.pdf" {
+		t.Fatalf("file_data = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_Nested verifies nested input_file object.
+func TestResponsesInputFile_Nested(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","input_file":{"file_id":"file-nested","filename":"nested.pdf"}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_id"]; got != "file-nested" {
+		t.Fatalf("file_id = %#v", got)
+	}
+	if got := file["filename"]; got != "nested.pdf" {
+		t.Fatalf("filename = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_TopLevelItem verifies top-level input_file item.
+func TestResponsesInputFile_TopLevelItem(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"input_file","file_id":"file-top"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	if user["role"] != "user" {
+		t.Fatalf("role = %#v", user["role"])
+	}
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	if filePart["type"] != "file" {
+		t.Fatalf("file part type = %#v", filePart["type"])
+	}
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_id"]; got != "file-top" {
+		t.Fatalf("file_id = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_MalformedReturns400 verifies malformed input_file
+// returns 400 and is not serialized as text.
+func TestResponsesInputFile_MalformedReturns400(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %s", ct)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["type"] != "invalid_request_error" {
+		t.Fatalf("error.type = %#v", errObj["type"])
+	}
+	if errObj["param"] != "input_file" {
+		t.Fatalf("error.param = %#v", errObj["param"])
+	}
+}
+
+// TestResponsesInputFile_NoTextLeak verifies a valid input_file is not
+// serialized as JSON text in the upstream body.
+func TestResponsesInputFile_NoTextLeak(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","file_id":"file-leak"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	raw, _ := json.Marshal(transport.requestPayloads[0])
+	if strings.Contains(string(raw), `"type":"input_file"`) {
+		t.Fatalf("input_file wrapper leaked as text: %s", raw)
+	}
+}
+
+// =====================================================================
+// Part C: temperature boundary validation
+// =====================================================================
+
+func tempReq(protocol string, temp float64) *http.Request {
+	body := `{"model":"primary-model","temperature":` + jsonFloat(temp) + `,"messages":[{"role":"user","content":"hi"}]}`
+	switch protocol {
+	case "claude":
+		body = `{"model":"primary-model","temperature":` + jsonFloat(temp) + `,"max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`
+	case "responses":
+		body = `{"model":"primary-model","temperature":` + jsonFloat(temp) + `,"input":"hi"}`
+	}
+	return httptest.NewRequest(http.MethodPost, "/"+protocolPath(protocol), strings.NewReader(body))
+}
+
+func protocolPath(protocol string) string {
+	switch protocol {
+	case "chat":
+		return "v1/chat/completions"
+	case "claude":
+		return "v1/messages"
+	case "responses":
+		return "v1/responses"
+	}
+	return ""
+}
+
+func jsonFloat(f float64) string {
+	b, _ := json.Marshal(f)
+	return string(b)
+}
+
+func runTempHandler(t *testing.T, protocol string, rec *httptest.ResponseRecorder, req *http.Request) {
+	t.Helper()
+	switch protocol {
+	case "chat":
+		chatCompletionsHandler(rec, req)
+	case "claude":
+		claudeMessagesHandler(rec, req)
+	case "responses":
+		responsesHandler(rec, req)
+	}
+}
+
+func assertTemp400(t *testing.T, rec *httptest.ResponseRecorder, protocol string) {
+	t.Helper()
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %s", ct)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v", body)
+	}
+	switch protocol {
+	case "claude":
+		if body["type"] != "error" {
+			t.Fatalf("type = %#v", body["type"])
+		}
+		errObj, _ := body["error"].(map[string]any)
+		if errObj["type"] != "invalid_request_error" {
+			t.Fatalf("error.type = %#v", errObj["type"])
+		}
+	default:
+		errObj, _ := body["error"].(map[string]any)
+		if errObj["type"] != "invalid_request_error" {
+			t.Fatalf("error.type = %#v", errObj["type"])
+		}
+		if errObj["param"] != "temperature" {
+			t.Fatalf("error.param = %#v", errObj["param"])
+		}
+	}
+}
+
+// TestTemperature_ClaudeRange verifies /v1/messages only accepts 0..1.
+func TestTemperature_ClaudeRange(t *testing.T) {
+	cases := []struct {
+		name   string
+		temp   float64
+		wantOK bool
+	}{
+		{"zero", 0, true},
+		{"one", 1, true},
+		{"midpoint", 0.5, true},
+		{"above_max", 1.5, false},
+		{"negative", -0.1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+			rec := httptest.NewRecorder()
+			runTempHandler(t, "claude", rec, tempReq("claude", tc.temp))
+			if tc.wantOK {
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200", rec.Code)
+				}
+				if len(transport.requestPayloads) != 1 {
+					t.Fatalf("upstream not called, payloads = %d", len(transport.requestPayloads))
+				}
+			} else {
+				assertTemp400(t, rec, "claude")
+				if len(transport.requestPayloads) != 0 {
+					t.Fatalf("upstream called on rejection, payloads = %d", len(transport.requestPayloads))
+				}
+			}
+		})
+	}
+}
+
+// TestTemperature_ChatRange verifies /v1/chat/completions accepts 0..2.
+func TestTemperature_ChatRange(t *testing.T) {
+	cases := []struct {
+		name   string
+		temp   float64
+		wantOK bool
+	}{
+		{"zero", 0, true},
+		{"two", 2, true},
+		{"midpoint", 1.5, true},
+		{"above_max", 2.5, false},
+		{"negative", -0.1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+			rec := httptest.NewRecorder()
+			runTempHandler(t, "chat", rec, tempReq("chat", tc.temp))
+			if tc.wantOK {
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200", rec.Code)
+				}
+				if len(transport.requestPayloads) != 1 {
+					t.Fatalf("upstream not called, payloads = %d", len(transport.requestPayloads))
+				}
+			} else {
+				assertTemp400(t, rec, "chat")
+				if len(transport.requestPayloads) != 0 {
+					t.Fatalf("upstream called on rejection, payloads = %d", len(transport.requestPayloads))
+				}
+			}
+		})
+	}
+}
+
+// TestTemperature_ResponsesRange verifies /v1/responses accepts 0..2.
+func TestTemperature_ResponsesRange(t *testing.T) {
+	cases := []struct {
+		name   string
+		temp   float64
+		wantOK bool
+	}{
+		{"zero", 0, true},
+		{"two", 2, true},
+		{"above_max", 3, false},
+		{"negative", -1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+			rec := httptest.NewRecorder()
+			runTempHandler(t, "responses", rec, tempReq("responses", tc.temp))
+			if tc.wantOK {
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200", rec.Code)
+				}
+				if len(transport.requestPayloads) != 1 {
+					t.Fatalf("upstream not called, payloads = %d", len(transport.requestPayloads))
+				}
+			} else {
+				assertTemp400(t, rec, "responses")
+				if len(transport.requestPayloads) != 0 {
+					t.Fatalf("upstream called on rejection, payloads = %d", len(transport.requestPayloads))
+				}
+			}
+		})
+	}
+}
+
+// TestTemperature_NilAccepted verifies absent temperature is accepted.
+func TestTemperature_NilAccepted(t *testing.T) {
+	for _, protocol := range []string{"chat", "claude", "responses"} {
+		t.Run(protocol, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+			var body string
+			switch protocol {
+			case "chat":
+				body = `{"model":"primary-model","messages":[{"role":"user","content":"hi"}]}`
+			case "claude":
+				body = `{"model":"primary-model","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`
+			case "responses":
+				body = `{"model":"primary-model","input":"hi"}`
+			}
+			rec := httptest.NewRecorder()
+			runTempHandler(t, protocol, rec, httptest.NewRequest(http.MethodPost, "/"+protocolPath(protocol), strings.NewReader(body)))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if len(transport.requestPayloads) != 1 {
+				t.Fatalf("upstream not called, payloads = %d", len(transport.requestPayloads))
+			}
+		})
+	}
+}
+
+// TestValidateTemperature_NaNRejected verifies NaN is rejected at helper level.
+// JSON cannot represent NaN, so this is tested at the helper level.
+func TestValidateTemperature_NaNRejected(t *testing.T) {
+	v := math.NaN()
+	if msg := validateTemperature(&v, 0, 2); msg == "" {
+		t.Fatal("NaN should be rejected")
+	}
+	if msg := validateTemperature(&v, 0, 1); msg == "" {
+		t.Fatal("NaN should be rejected for claude range")
+	}
+}
+
+// TestValidateTemperature_InfRejected verifies +Inf is rejected at helper level.
+func TestValidateTemperature_InfRejected(t *testing.T) {
+	v := math.Inf(1)
+	if msg := validateTemperature(&v, 0, 2); msg == "" {
+		t.Fatal("+Inf should be rejected")
+	}
+	negInf := math.Inf(-1)
+	if msg := validateTemperature(&negInf, 0, 2); msg == "" {
+		t.Fatal("-Inf should be rejected")
+	}
+}
+
+// TestValidateTemperature_NilAccepted verifies nil is accepted at helper level.
+func TestValidateTemperature_NilAccepted(t *testing.T) {
+	if msg := validateTemperature(nil, 0, 2); msg != "" {
+		t.Fatalf("nil should be accepted, got %q", msg)
+	}
+}
+
+// TestTemperature_StreamRequestReturnsJSON400 verifies streaming requests also
+// get a plain JSON 400 before any SSE starts.
+func TestTemperature_StreamRequestReturnsJSON400(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	body := `{"model":"primary-model","temperature":3,"stream":true,"input":"hi"}`
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %s, want application/json (not SSE)", ct)
+	}
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj["type"] != "invalid_request_error" {
+		t.Fatalf("error.type = %#v", errObj["type"])
+	}
+}
+
+// =====================================================================
+// Part A unit-level: helpers
+// =====================================================================
+
+func TestNormalizeToolResultOutput_StandardOutputString(t *testing.T) {
+	text, present := normalizeToolResultOutput(map[string]any{"output": "hello"})
+	if !present || text != "hello" {
+		t.Fatalf("got (%q, %v)", text, present)
+	}
+}
+
+func TestNormalizeToolResultOutput_ContentString(t *testing.T) {
+	text, present := normalizeToolResultOutput(map[string]any{"content": "world"})
+	if !present || text != "world" {
+		t.Fatalf("got (%q, %v)", text, present)
+	}
+}
+
+func TestNormalizeToolResultOutput_ContentTypedBlocks(t *testing.T) {
+	text, present := normalizeToolResultOutput(map[string]any{"content": []any{
+		map[string]any{"type": "text", "text": "a"},
+		map[string]any{"type": "output_text", "text": "b"},
+		map[string]any{"type": "input_text", "text": "c"},
+	}})
+	if !present || text != "a\nb\nc" {
+		t.Fatalf("got (%q, %v)", text, present)
+	}
+}
+
+func TestNormalizeToolResultOutput_EmptyStringPresent(t *testing.T) {
+	text, present := normalizeToolResultOutput(map[string]any{"content": ""})
+	if !present || text != "" {
+		t.Fatalf("got (%q, %v), want present empty", text, present)
+	}
+}
+
+func TestNormalizeToolResultOutput_MissingPayload(t *testing.T) {
+	_, present := normalizeToolResultOutput(map[string]any{"type": "tool_result"})
+	if present {
+		t.Fatal("want not present for missing payload")
+	}
+}
+
+func TestApplyErrorPrefix_NoDoublePrefix(t *testing.T) {
+	if got := applyErrorPrefix("Error: already"); got != "Error: already" {
+		t.Fatalf("got %q", got)
+	}
+	if got := applyErrorPrefix("boom"); got != "Error: boom" {
+		t.Fatalf("got %q", got)
+	}
+	if got := applyErrorPrefix(""); got != "Error: " {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCountClaudeThinkingSignatures(t *testing.T) {
+	msgs := []ClaudeMessage{{
+		Role: "assistant",
+		Content: []any{
+			map[string]any{"type": "thinking", "thinking": "h1", "signature": "sig1"},
+			map[string]any{"type": "thinking", "thinking": "h2", "signature": ""},
+			map[string]any{"type": "thinking", "thinking": "h3"},
+			map[string]any{"type": "text", "text": "answer"},
+		},
+	}}
+	if n := countClaudeThinkingSignatures(msgs); n != 1 {
+		t.Fatalf("signature count = %d, want 1", n)
+	}
+}
+
+// =====================================================================
+// Fix 1: is_error order-independence and missing payload
+// =====================================================================
+
+// TestResponsesToolResult_IsErrorOutputBeforeCall verifies that is_error
+// prefix is applied regardless of whether the output item appears before or
+// after the call item in the array. Also asserts the exact message sequence
+// is assistant(call) then exactly one tool result (no leading duplicate).
+func TestResponsesToolResult_IsErrorOutputBeforeCall(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// output item appears BEFORE the call item in the array
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"tool_result","call_id":"call_err","is_error":true,"content":"boom"},
+			{"type":"function_call","call_id":"call_err","name":"f","arguments":"{}"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Assert exact sequence: assistant(call_err) then exactly one tool message
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2 (assistant + tool, no duplicate): %#v", len(messages), messages)
+	}
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant", m0["role"])
+	}
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "call_err" {
+		t.Fatalf("tool_call_id = %#v, want call_err", m1["tool_call_id"])
+	}
+	if got := m1["content"]; got != "Error: boom" {
+		t.Fatalf("tool content = %#v, want 'Error: boom'", got)
+	}
+}
+
+// TestResponsesToolResult_IsErrorOutputAfterCall verifies is_error when
+// output appears after the call item (the original order). Also asserts the
+// exact message sequence is assistant(call) then exactly one tool result.
+func TestResponsesToolResult_IsErrorOutputAfterCall(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_err","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_err","is_error":true,"content":"boom"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Assert exact sequence: assistant(call_err) then exactly one tool message
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2 (assistant + tool, no duplicate): %#v", len(messages), messages)
+	}
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant", m0["role"])
+	}
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "call_err" {
+		t.Fatalf("tool_call_id = %#v, want call_err", m1["tool_call_id"])
+	}
+	if got := m1["content"]; got != "Error: boom" {
+		t.Fatalf("tool content = %#v, want 'Error: boom'", got)
+	}
+}
+
+// TestResponsesToolResult_NoPayloadGivesMissing verifies that a tool_result
+// with no output and no content field is treated as missing (not empty), and
+// gets "[tool output missing]".
+func TestResponsesToolResult_NoPayloadGivesMissing(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_no","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_no"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" {
+			if got := mm["content"]; got != "[tool output missing]" {
+				t.Fatalf("tool content = %#v, want '[tool output missing]'", got)
+			}
+			return
+		}
+	}
+	t.Fatal("no tool message found")
+}
+
+// TestNormalizeToolResultOutput_IsErrorApplied verifies the helper itself
+// applies the is_error prefix.
+func TestNormalizeToolResultOutput_IsErrorApplied(t *testing.T) {
+	text, present := normalizeToolResultOutput(map[string]any{
+		"content":  "failure",
+		"is_error": true,
+	})
+	if !present {
+		t.Fatal("want present")
+	}
+	if text != "Error: failure" {
+		t.Fatalf("got %q, want 'Error: failure'", text)
+	}
+}
+
+// TestNormalizeToolResultOutput_IsErrorNotAppliedWhenFalse verifies no prefix
+// when is_error is absent or false.
+func TestNormalizeToolResultOutput_IsErrorNotAppliedWhenFalse(t *testing.T) {
+	text, _ := normalizeToolResultOutput(map[string]any{"content": "ok"})
+	if text != "ok" {
+		t.Fatalf("got %q, want 'ok'", text)
+	}
+	text, _ = normalizeToolResultOutput(map[string]any{
+		"content":  "ok",
+		"is_error": false,
+	})
+	if text != "ok" {
+		t.Fatalf("got %q, want 'ok'", text)
+	}
+}
+
+// TestCollectFunctionOutputs_IsErrorBakedIntoMap verifies that
+// collectFunctionOutputs already includes the is_error prefix in the map,
+// making it order-independent.
+func TestCollectFunctionOutputs_IsErrorBakedIntoMap(t *testing.T) {
+	outputs := collectFunctionOutputs([]any{
+		map[string]any{
+			"type":     "tool_result",
+			"call_id":  "call_x",
+			"content":  "boom",
+			"is_error": true,
+		},
+	})
+	if got, ok := outputs["call_x"]; !ok || got != "Error: boom" {
+		t.Fatalf("outputs[call_x] = %q (ok=%v), want 'Error: boom'", got, ok)
+	}
+}
+
+// TestCollectFunctionOutputs_NoPayloadAbsent verifies that a tool_result with
+// no payload leaves the key absent (not set to empty string).
+func TestCollectFunctionOutputs_NoPayloadAbsent(t *testing.T) {
+	outputs := collectFunctionOutputs([]any{
+		map[string]any{
+			"type":    "tool_result",
+			"call_id": "call_missing",
+		},
+	})
+	if _, ok := outputs["call_missing"]; ok {
+		t.Fatal("key should be absent for missing payload")
+	}
+}
+
+// TestCollectFunctionOutputs_EmptyContentPresent verifies that an explicit
+// empty content string IS present in the map.
+func TestCollectFunctionOutputs_EmptyContentPresent(t *testing.T) {
+	outputs := collectFunctionOutputs([]any{
+		map[string]any{
+			"type":    "tool_result",
+			"call_id": "call_empty",
+			"content": "",
+		},
+	})
+	got, ok := outputs["call_empty"]
+	if !ok {
+		t.Fatal("key should be present for explicit empty content")
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty string", got)
+	}
+}
+
+// =====================================================================
+// Fix 2: responsesInputFileToFile field selection
+// =====================================================================
+
+// TestResponsesInputFile_NestedOnlyFileURL verifies that a nested-only
+// file_url maps to file.file_data.
+func TestResponsesInputFile_NestedOnlyFileURL(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","input_file":{"file_url":"https://example.test/nested.pdf"}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	file, _ := filePart["file"].(map[string]any)
+	if got := file["file_data"]; got != "https://example.test/nested.pdf" {
+		t.Fatalf("file_data = %#v", got)
+	}
+}
+
+// TestResponsesInputFile_NestedEmptyPayloadReturns400 verifies that a nested
+// input_file with only empty strings returns 400.
+func TestResponsesInputFile_NestedEmptyPayloadReturns400(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","input_file":{"file_data":"","file_id":"","file_url":""}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestResponsesInputFile_UnknownFieldNotLeaked verifies that unknown fields in
+// the input_file (flat or nested) do not leak into the Chat file object.
+func TestResponsesInputFile_UnknownFieldNotLeaked(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_file","file_id":"file-abc","filename":"doc.pdf","custom_field":"leak","priority":99,
+			 "input_file":{"file_id":"file-nested","extra":"should-not-leak"}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	content, _ := user["content"].([]any)
+	filePart, _ := content[0].(map[string]any)
+	file, _ := filePart["file"].(map[string]any)
+	// Only file_data / file_id / filename should exist
+	for key := range file {
+		if key != "file_data" && key != "file_id" && key != "filename" {
+			t.Fatalf("unexpected field %q in file object: %#v", key, file)
+		}
+	}
+	if _, leaked := file["custom_field"]; leaked {
+		t.Fatal("custom_field leaked")
+	}
+	if _, leaked := file["priority"]; leaked {
+		t.Fatal("priority leaked")
+	}
+	if _, leaked := file["extra"]; leaked {
+		t.Fatal("nested extra leaked")
+	}
+}
+
+// =====================================================================
+// Fix 3: per-tool_result attachment labeling
+// =====================================================================
+
+// TestClaudeParallelToolResults_DocumentOnlyFirst verifies that when two
+// parallel tool_results exist (first with a document, second pure text), only
+// the first gets [document attached] and the second does not.
+func TestClaudeParallelToolResults_DocumentOnlyFirst(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_doc","name":"get_doc","input":{}}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_txt","name":"get_text","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"call_doc","content":[
+					{"type":"text","text":"here is the doc"},
+					{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}}
+				]},
+				{"type":"tool_result","tool_use_id":"call_txt","content":[
+					{"type":"text","text":"plain text result"}
+				]}
+			]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Find both tool messages
+	var docTool, txtTool map[string]any
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" {
+			switch mm["tool_call_id"] {
+			case "call_doc":
+				docTool = mm
+			case "call_txt":
+				txtTool = mm
+			}
+		}
+	}
+	if docTool == nil {
+		t.Fatal("call_doc tool message not found")
+	}
+	if txtTool == nil {
+		t.Fatal("call_txt tool message not found")
+	}
+	docContent, _ := docTool["content"].(string)
+	if !strings.Contains(docContent, "[document attached]") {
+		t.Fatalf("doc tool content should contain [document attached]: %q", docContent)
+	}
+	if !strings.Contains(docContent, "here is the doc") {
+		t.Fatalf("doc tool content should contain text: %q", docContent)
+	}
+	txtContent, _ := txtTool["content"].(string)
+	if strings.Contains(txtContent, "[document attached]") {
+		t.Fatalf("text tool should NOT contain [document attached]: %q", txtContent)
+	}
+	if strings.Contains(txtContent, "[image attached]") {
+		t.Fatalf("text tool should NOT contain [image attached]: %q", txtContent)
+	}
+	if txtContent != "plain text result" {
+		t.Fatalf("text tool content = %q, want 'plain text result'", txtContent)
+	}
+}
+
+// TestClaudeToolResult_MixedImageAndDocument verifies image and document
+// attachments in the same tool_result are both labeled in original order.
+func TestClaudeToolResult_MixedImageAndDocument(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"call_mix","name":"f","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_mix","content":[
+				{"type":"image","source":{"type":"url","url":"https://example.test/a.png"}},
+				{"type":"document","source":{"type":"url","url":"https://example.test/d.pdf"}}
+			]}]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" {
+			content, _ := mm["content"].(string)
+			// Both labels should appear in image-then-document order
+			imgIdx := strings.Index(content, "[image attached]")
+			docIdx := strings.Index(content, "[document attached]")
+			if imgIdx < 0 || docIdx < 0 {
+				t.Fatalf("missing labels in content: %q", content)
+			}
+			if imgIdx > docIdx {
+				t.Fatalf("image should come before document: %q", content)
+			}
+			return
+		}
+	}
+	t.Fatal("no tool message found")
+}
+
+// =====================================================================
+// Fix 4: Responses validator does not handle document alias
+// =====================================================================
+
+// TestResponsesValidator_DocumentAliasNotValidated verifies that a Responses
+// input containing a type:"document" item does NOT trigger the file validator
+// (document is a /v1/messages concept, not a Responses alias). The validator
+// only checks input_file; a document item is not rejected by the file-input
+// 400 check and passes through to the upstream.
+func TestResponsesValidator_DocumentAliasNotValidated(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// An actual type:"document" item in Responses input. It must NOT produce
+	// a 400 from the file validator — the validator only handles input_file.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"document","source":{"type":"url","url":"https://example.test/doc.pdf"}}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	// The document item is not validated by the file-input check, so it does
+	// not get a 400 from that check. It reaches the upstream (as text via the
+	// default item handler), confirming no file-input validation error.
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (document must not trigger file validator): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called (document not blocked by file validator), payloads = %d", len(transport.requestPayloads))
+	}
+}
+
+// =====================================================================
+// Fix A: cache_control counting (tool-level field, not schema properties)
+// =====================================================================
+
+// TestCountClaudeCacheControlBlocks_ToolLevelField verifies that a
+// cache_control on a tool definition (the official tool-level breakpoint) is
+// counted, but a cache_control property inside input_schema is NOT counted.
+func TestCountClaudeCacheControlBlocks_ToolLevelField(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-test",
+		"max_tokens":100,
+		"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]}
+		],
+		"tools":[
+			{
+				"name":"get_weather",
+				"description":"Get weather",
+				"input_schema":{
+					"type":"object",
+					"properties":{
+						"location":{"type":"string"},
+						"cache_control":{"type":"string","description":"not a real breakpoint"}
+					}
+				},
+				"cache_control":{"type":"ephemeral"}
+			}
+		]
+	}`)
+	var req ClaudeRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatal(err)
+	}
+	n := countClaudeCacheControlBlocks(req)
+	// Expected: 1 (system) + 1 (message content block) + 1 (tool-level) = 3
+	// The input_schema property named "cache_control" must NOT be counted.
+	if n != 3 {
+		t.Fatalf("cache_control_blocks = %d, want 3 (system + message + tool-level, not schema property)", n)
+	}
+}
+
+// TestCountClaudeCacheControlBlocks_ToolUseInputNotCounted verifies that a
+// cache_control key inside a tool_use input object is not counted.
+func TestCountClaudeCacheControlBlocks_ToolUseInputNotCounted(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-test",
+		"max_tokens":100,
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"tool_use","id":"call_1","name":"f","input":{"cache_control":"not a breakpoint"}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"ok"}]}
+		],
+		"tools":[
+			{"name":"f","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}
+		]
+	}`)
+	var req ClaudeRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatal(err)
+	}
+	n := countClaudeCacheControlBlocks(req)
+	// No actual breakpoints — tool_use input cache_control is NOT counted.
+	if n != 0 {
+		t.Fatalf("cache_control_blocks = %d, want 0 (tool_use input cache_control is not a breakpoint)", n)
+	}
+}
+
+// TestClaudeToolCacheControlUnmarshals verifies that the CacheControl field
+// on ClaudeTool is populated from JSON (not silently dropped).
+func TestClaudeToolCacheControlUnmarshals(t *testing.T) {
+	raw := []byte(`{
+		"name":"f",
+		"input_schema":{"type":"object"},
+		"cache_control":{"type":"ephemeral"}
+	}`)
+	var tool ClaudeTool
+	if err := json.Unmarshal(raw, &tool); err != nil {
+		t.Fatal(err)
+	}
+	if tool.CacheControl == nil {
+		t.Fatal("CacheControl should be unmarshaled, got nil")
+	}
+	m, ok := tool.CacheControl.(map[string]any)
+	if !ok {
+		t.Fatalf("CacheControl = %#v, want map", tool.CacheControl)
+	}
+	if m["type"] != "ephemeral" {
+		t.Fatalf("CacheControl.type = %#v, want ephemeral", m["type"])
+	}
+}
+
+// =====================================================================
+// Fix B: countClaudeThinkingSignatures false-positive regression
+// =====================================================================
+
+// TestCountClaudeThinkingSignatures_NoNestedFalsePositive verifies that a
+// user/tool input object with type:"thinking" and a signature key is NOT
+// counted, because only top-level message content blocks are valid history
+// thinking blocks.
+func TestCountClaudeThinkingSignatures_NoNestedFalsePositive(t *testing.T) {
+	msgs := []ClaudeMessage{
+		{
+			Role: "assistant",
+			Content: []any{
+				map[string]any{"type": "thinking", "thinking": "real", "signature": "real_sig"},
+				map[string]any{"type": "text", "text": "answer"},
+			},
+		},
+		{
+			Role: "user",
+			Content: []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "call_1", "content": []any{
+					// This is inside tool_result content, NOT a history thinking block.
+					map[string]any{"type": "thinking", "signature": "not_a_history_block"},
+				}},
+			},
+		},
+	}
+	n := countClaudeThinkingSignatures(msgs)
+	if n != 1 {
+		t.Fatalf("signature count = %d, want 1 (only the real top-level thinking block)", n)
+	}
+}
+
+// TestCountClaudeThinkingSignatures_StringContentNotCounted verifies that a
+// message with string content (not a content array) does not crash and
+// returns 0.
+func TestCountClaudeThinkingSignatures_StringContentNotCounted(t *testing.T) {
+	msgs := []ClaudeMessage{
+		{Role: "user", Content: "just a string"},
+	}
+	n := countClaudeThinkingSignatures(msgs)
+	if n != 0 {
+		t.Fatalf("signature count = %d, want 0 for string content", n)
+	}
+}
+
+// =====================================================================
+// Fix 1: output-before-call exact sequence regression
+// =====================================================================
+
+// TestResponsesToolResult_OutputBeforeCall_NoLeadingDuplicate verifies that
+// when output precedes call, the result is assistant(call) then exactly one
+// tool message — no leading duplicate tool message.
+func TestResponsesToolResult_OutputBeforeCall_NoLeadingDuplicate(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"tool_result","call_id":"call_x","content":"result"},
+			{"type":"function_call","call_id":"call_x","name":"f","arguments":"{}"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want exactly 2 (assistant + 1 tool, no duplicate): %#v", len(messages), messages)
+	}
+	// First must be assistant, not tool
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant (no leading tool)", m0["role"])
+	}
+	// Second must be the single tool message
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "call_x" {
+		t.Fatalf("tool_call_id = %#v, want call_x", m1["tool_call_id"])
+	}
+	if m1["content"] != "result" {
+		t.Fatalf("content = %#v, want 'result'", m1["content"])
+	}
+}
+
+// TestResponsesToolResult_CallBeforeOutput_NoDuplicate verifies the original
+// order (call before output) also produces exactly assistant + 1 tool.
+func TestResponsesToolResult_CallBeforeOutput_NoDuplicate(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_y","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_y","content":"result_y"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want exactly 2: %#v", len(messages), messages)
+	}
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant", m0["role"])
+	}
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "call_y" {
+		t.Fatalf("tool_call_id = %#v, want call_y", m1["tool_call_id"])
+	}
+	if m1["content"] != "result_y" {
+		t.Fatalf("content = %#v, want 'result_y'", m1["content"])
+	}
+}
+
+// TestResponsesToolResult_StandaloneOutputStillWorks verifies that a
+// standalone output with no matching call in the same array still produces
+// a tool message (for previous-response-id replay scenarios).
+func TestResponsesToolResult_StandaloneOutputStillWorks(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// Only an output, no matching call — should still produce a tool message
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"tool_result","call_id":"call_standalone","content":"standalone result"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Should have at least one tool message with the standalone output
+	found := false
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" && mm["tool_call_id"] == "call_standalone" {
+			if mm["content"] != "standalone result" {
+				t.Fatalf("content = %#v, want 'standalone result'", mm["content"])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("standalone tool message not found")
+	}
+}
+
+// =====================================================================
+// Fix 2: validateClaudeDocumentBlocks content-structure-aware
+// =====================================================================
+
+// TestClaudeValidateDocument_ToolUseInputNotFalsePositive verifies that a
+// tool_use block whose input contains a field like {kind:{type:"document"}}
+// does NOT trigger a false document validation (it must reach upstream).
+func TestClaudeValidateDocument_ToolUseInputNotFalsePositive(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"assistant","content":[
+			{"type":"tool_use","id":"call_1","name":"classify","input":{"kind":{"type":"document"}}}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (tool_use input should not trigger document validation)", rec.Code)
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+}
+
+// TestClaudeValidateDocument_MalformedInToolResultContent verifies that a
+// malformed document nested inside tool_result.content is still rejected
+// with a 400 (without reaching upstream).
+func TestClaudeValidateDocument_MalformedInToolResultContent(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"call_1","content":[
+				{"type":"text","text":"result"},
+				{"type":"document","source":{"type":"base64","data":""}}
+			]}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (malformed document in tool_result content)", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type = %s", ct)
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["type"] != "invalid_request_error" {
+		t.Fatalf("error.type = %#v", errObj["type"])
+	}
+}
+
+// TestClaudeValidateDocument_ValidInToolResultContent verifies that a valid
+// document inside tool_result.content passes validation and reaches upstream.
+func TestClaudeValidateDocument_ValidInToolResultContent(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"primary-model",
+		"max_tokens":256,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"call_1","content":[
+				{"type":"text","text":"result"},
+				{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}}
+			]}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (valid document should pass)", rec.Code)
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+}
+
+// =====================================================================
+// Test hardening: streaming temperature 400 across all protocols
+// =====================================================================
+
+// TestTemperature_Stream400_AllProtocols verifies that invalid streaming
+// temperature returns JSON 400 (not SSE) across chat, claude, and responses,
+// and that the upstream is never called.
+func TestTemperature_Stream400_AllProtocols(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol string
+		body     string
+	}{
+		{
+			name:     "chat",
+			protocol: "chat",
+			body:     `{"model":"primary-model","temperature":3,"stream":true,"messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:     "claude",
+			protocol: "claude",
+			body:     `{"model":"primary-model","temperature":2,"stream":true,"max_tokens":256,"messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name:     "responses",
+			protocol: "responses",
+			body:     `{"model":"primary-model","temperature":3,"stream":true,"input":"hi"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+				status: http.StatusOK,
+				body:   okChatBody(),
+			}})
+			rec := httptest.NewRecorder()
+			runTempHandler(t, tc.protocol, rec, httptest.NewRequest(http.MethodPost, "/"+protocolPath(tc.protocol), strings.NewReader(tc.body)))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+				t.Fatalf("content-type = %s, want application/json (not SSE)", ct)
+			}
+			var resp map[string]any
+			json.Unmarshal(rec.Body.Bytes(), &resp)
+			switch tc.protocol {
+			case "claude":
+				if resp["type"] != "error" {
+					t.Fatalf("type = %#v", resp["type"])
+				}
+				errObj, _ := resp["error"].(map[string]any)
+				if errObj["type"] != "invalid_request_error" {
+					t.Fatalf("error.type = %#v", errObj["type"])
+				}
+			default:
+				errObj, _ := resp["error"].(map[string]any)
+				if errObj["type"] != "invalid_request_error" {
+					t.Fatalf("error.type = %#v", errObj["type"])
+				}
+				if errObj["param"] != "temperature" {
+					t.Fatalf("error.param = %#v", errObj["param"])
+				}
+			}
+			if len(transport.requestPayloads) != 0 {
+				t.Fatalf("upstream should not be called on rejection, payloads = %d", len(transport.requestPayloads))
+			}
+		})
+	}
+}
+
+// TestResponsesToolResult_OutputBeforeCall_NestedToolUseWrapper verifies
+// that output-before-call with a nested tool_use wrapper (where call ID is
+// extracted from tool_use.id, not top-level call_id) does not produce a
+// leading duplicate tool message.
+func TestResponsesToolResult_OutputBeforeCall_NestedToolUseWrapper(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// output (tool_use_id) before call (tool_use.id wrapper)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"tool_result","tool_use_id":"c_nested","content":"nested result"},
+			{"type":"tool_call","tool_use":{"id":"c_nested","name":"f","input":{}}}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	// Assert exact sequence: assistant(call) then exactly one tool message
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want exactly 2 (assistant + 1 tool, no duplicate): %#v", len(messages), messages)
+	}
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant (no leading tool)", m0["role"])
+	}
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "c_nested" {
+		t.Fatalf("tool_call_id = %#v, want c_nested", m1["tool_call_id"])
+	}
+	if m1["content"] != "nested result" {
+		t.Fatalf("content = %#v, want 'nested result'", m1["content"])
+	}
+}
+
+// TestResponsesToolResult_CallBeforeOutput_NestedToolUseWrapper verifies the
+// call-before-output order with the nested tool_use wrapper also produces
+// exactly assistant + 1 tool.
+func TestResponsesToolResult_CallBeforeOutput_NestedToolUseWrapper(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"tool_call","tool_use":{"id":"c_nested2","name":"f","input":{}}},
+			{"type":"tool_result","tool_use_id":"c_nested2","content":"nested result 2"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want exactly 2: %#v", len(messages), messages)
+	}
+	m0, _ := messages[0].(map[string]any)
+	if m0["role"] != "assistant" {
+		t.Fatalf("messages[0] role = %#v, want assistant", m0["role"])
+	}
+	m1, _ := messages[1].(map[string]any)
+	if m1["role"] != "tool" {
+		t.Fatalf("messages[1] role = %#v, want tool", m1["role"])
+	}
+	if m1["tool_call_id"] != "c_nested2" {
+		t.Fatalf("tool_call_id = %#v, want c_nested2", m1["tool_call_id"])
+	}
+	if m1["content"] != "nested result 2" {
+		t.Fatalf("content = %#v, want 'nested result 2'", m1["content"])
+	}
+}
+
+// TestResponsesValidator_ToolCallInputNotFalsePositive verifies that a
+// function_call item whose arguments contain a nested object with
+// type:"input_file" does NOT trigger the file validator (it must reach
+// upstream). The validator only inspects top-level items and message content
+// arrays, not function/tool arguments or nested tool_use.input.
+func TestResponsesValidator_ToolCallInputNotFalsePositive(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// A function_call with arguments that happen to contain type:"input_file"
+	// nested inside a tool argument — must NOT be rejected by the file
+	// validator.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{
+				"type":"function_call",
+				"call_id":"call_fp",
+				"name":"upload",
+				"arguments":"{\"files\":[{\"type\":\"input_file\",\"file_id\":\"nonexistent\"}]}"
+			}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (tool arguments must not trigger file validator): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+}
+
+// TestResponsesValidator_ToolCallNestedToolUseInputNotFalsePositive verifies
+// that a tool_call with a nested tool_use.input containing type:"input_file"
+// is not falsely rejected.
+func TestResponsesValidator_ToolCallNestedToolUseInputNotFalsePositive(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{
+				"type":"tool_call",
+				"tool_use":{
+					"id":"call_tu",
+					"name":"process",
+					"input":{"attachment":{"type":"input_file"}}
+				}
+			}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (nested tool_use.input must not trigger file validator): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+}
+
+// TestResponsesValidator_MessageContentInputFileStillValidated verifies that
+// an actual input_file content part inside a message content array IS still
+// validated (the structure-aware validator does not skip real content parts).
+func TestResponsesValidator_MessageContentInputFileStillValidated(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	// A real input_file content part with no payload inside a message — must
+	// still be rejected with 400.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[{"role":"user","content":[
+			{"type":"input_text","text":"hi"},
+			{"type":"input_file"}
+		]}]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (actual input_file content part must be validated)", rec.Code)
+	}
+}
+
+// TestResponsesValidator_TopLevelInputFileStillValidated verifies that a
+// top-level input_file item with no payload is still rejected.
+func TestResponsesValidator_TopLevelInputFileStillValidated(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{status: http.StatusOK, body: okChatBody()}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"input_file"}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (top-level input_file must be validated)", rec.Code)
+	}
+}
+
+// TestResponsesMessages_FieldUsesChatShapes_NotResponsesInputFile verifies
+// that the nonstandard `messages` compatibility field uses Chat content
+// shapes. A Responses-style input_file part in messages[].content is NOT
+// validated or converted — it is forwarded as-is. Use the official `input`
+// field for input_file support.
+func TestResponsesMessages_FieldUsesChatShapes_NotResponsesInputFile(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// A Responses-style input_file in messages[].content. It should NOT be
+	// rejected by the validator (the messages field uses Chat content shapes),
+	// and it should be forwarded as-is (not converted to type:"file").
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"messages":[
+			{"role":"user","content":[
+				{"type":"input_file","file_id":"file-msg-test"}
+			]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	// Should reach upstream (not rejected by file validator)
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (messages field should not validate Responses input_file): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+	// The input_file part is forwarded as-is (not converted to type:"file")
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	user, _ := messages[0].(map[string]any)
+	contentParts, _ := user["content"].([]any)
+	part, _ := contentParts[0].(map[string]any)
+	if part["type"] != "input_file" {
+		t.Fatalf("part type = %#v, want input_file (messages field forwards as-is, not converted to file)", part["type"])
+	}
+}
+
+// TestResponsesValidator_InputFileInToolResultNotValidated verifies that an
+// input_file-looking object inside a tool_result/function_call_output content
+// array is NOT treated as a supported file input. It is not validated (no
+// 400), and it is silently normalized to empty output by the text-only
+// joinToolResultContent path — proving this location is not supported.
+func TestResponsesValidator_InputFileInToolResultNotValidated(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	// An input_file-looking object inside a tool_result content array.
+	// It must NOT be validated as a file input (no 400), because
+	// tool_result content uses text shapes only.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_tr","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_tr","content":[
+				{"type":"input_file","file_id":"should-be-ignored"},
+				{"type":"text","text":"actual text result"}
+			]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	// Must NOT be rejected by the file validator
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (input_file in tool_result content must not be validated): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+	// The input_file part is silently dropped (not converted to file), and
+	// only the text part is preserved as the tool output.
+	messages, _ := transport.requestPayloads[0]["messages"].([]any)
+	for _, m := range messages {
+		mm, _ := m.(map[string]any)
+		if mm["role"] == "tool" {
+			if got := mm["content"]; got != "actual text result" {
+				t.Fatalf("tool content = %#v, want 'actual text result' (input_file in tool_result is not supported, only text)", got)
+			}
+			return
+		}
+	}
+	t.Fatal("no tool message found")
+}
+
+// TestResponsesValidator_MalformedInputFileInToolResultNotRejected verifies
+// that a malformed (no payload) input_file inside tool_result content does
+// NOT produce a file-specific 400 — it is silently ignored.
+func TestResponsesValidator_MalformedInputFileInToolResultNotRejected(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"primary-model",
+		"input":[
+			{"type":"function_call","call_id":"call_mal","name":"f","arguments":"{}"},
+			{"type":"tool_result","call_id":"call_mal","content":[
+				{"type":"input_file"},
+				{"type":"text","text":"ok"}
+			]}
+		]
+	}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("status = 400, want non-400 (malformed input_file in tool_result must not trigger file 400): %s", rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream should be called, payloads = %d", len(transport.requestPayloads))
+	}
+}

--- a/stream_integrity_test.go
+++ b/stream_integrity_test.go
@@ -1,0 +1,666 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- helpers ---
+
+func hasEvent(events []sseEvent, name string) bool {
+	for _, e := range events {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func countEvent(events []sseEvent, name string) int {
+	n := 0
+	for _, e := range events {
+		if e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// errorReader simulates a non-EOF read error after writing some data.
+type errorReader struct {
+	data   string
+	pos    int
+	errMsg string
+}
+
+func (e *errorReader) Read(p []byte) (int, error) {
+	if e.pos >= len(e.data) {
+		return 0, io.ErrClosedPipe
+	}
+	n := copy(p, e.data[e.pos:])
+	e.pos += n
+	if e.pos >= len(e.data) {
+		return n, io.ErrClosedPipe
+	}
+	return n, nil
+}
+
+func (e *errorReader) Close() error { return nil }
+
+// slowReader simulates a reader that blocks until closed, to test keepalive.
+type slowReader struct {
+	closed chan struct{}
+}
+
+func newSlowReader() *slowReader {
+	return &slowReader{closed: make(chan struct{})}
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	<-s.closed
+	return 0, io.EOF
+}
+
+func (s *slowReader) Close() error {
+	select {
+	case <-s.closed:
+	default:
+		close(s.closed)
+	}
+	return nil
+}
+
+// safeRecorder wraps httptest.ResponseRecorder so tests can read the body
+// concurrently while the handler goroutine may still be writing.
+type safeRecorder struct {
+	mu sync.Mutex
+	rr *httptest.ResponseRecorder
+}
+
+func newSafeRecorder() *safeRecorder {
+	return &safeRecorder{rr: httptest.NewRecorder()}
+}
+
+func (s *safeRecorder) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rr.Write(p)
+}
+func (s *safeRecorder) WriteHeader(code int) { s.rr.WriteHeader(code) }
+func (s *safeRecorder) Header() http.Header  { return s.rr.Header() }
+
+func (s *safeRecorder) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rr.Body.String()
+}
+
+// =====================================================================
+// Claude stream handler tests
+// =====================================================================
+
+func TestClaudeStream_PartialEOF_NoFinish_ErrorOnly(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event, got:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") {
+		t.Fatalf("must not emit message_stop on partial EOF:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_delta on partial EOF:\n%s", rr.Body.String())
+	}
+	// message_start is expected — the stream did deliver content before EOF.
+	// What must NOT happen: message_delta, message_stop, end_turn.
+	// Verify error structure
+	for _, e := range events {
+		if e.Name == "error" {
+			errObj, ok := e.Data["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("error event missing error object: %#v", e.Data)
+			}
+			if errObj["type"] != "api_error" {
+				t.Fatalf("error type = %#v, want api_error", errObj["type"])
+			}
+			if errObj["message"] == "" {
+				t.Fatalf("error message empty: %#v", errObj)
+			}
+		}
+	}
+}
+
+func TestClaudeStream_DoneNoFinish_ErrorOnly(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event for [DONE] without finish:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta on [DONE] without finish:\n%s", rr.Body.String())
+	}
+}
+
+func TestClaudeStream_InBandError_ErrorOnly(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}`,
+		``,
+		`data: {"error":{"type":"rate_limit_error","message":"quota exceeded"}}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event for in-band error:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta on in-band error:\n%s", rr.Body.String())
+	}
+	// Verify the error message is propagated
+	for _, e := range events {
+		if e.Name == "error" {
+			errObj, _ := e.Data["error"].(map[string]any)
+			msg, _ := errObj["message"].(string)
+			if !strings.Contains(msg, "quota exceeded") {
+				t.Fatalf("error message should contain 'quota exceeded', got %q", msg)
+			}
+		}
+	}
+}
+
+func TestClaudeStream_ReaderError_ErrorOnly(t *testing.T) {
+	er := &errorReader{
+		data: "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+	}
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, er, "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event for reader error:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta on reader error:\n%s", rr.Body.String())
+	}
+}
+
+func TestClaudeStream_BadJSON_ErrorOnly(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		`data: {not valid json}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event for bad JSON:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta on bad JSON:\n%s", rr.Body.String())
+	}
+}
+
+func TestClaudeStream_NormalFinishWithUsage(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hello world"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if hasEvent(events, "error") {
+		t.Fatalf("must not emit error on normal finish:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "message_start") {
+		t.Fatalf("expected message_start:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "message_delta") {
+		t.Fatalf("expected message_delta:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "message_stop") {
+		t.Fatalf("expected message_stop:\n%s", rr.Body.String())
+	}
+	// Verify usage in message_delta
+	for _, e := range events {
+		if e.Name == "message_delta" {
+			usage, ok := e.Data["usage"].(map[string]any)
+			if !ok {
+				t.Fatalf("message_delta missing usage: %#v", e.Data["usage"])
+			}
+			in, _ := usage["input_tokens"].(float64)
+			if int(in) != 10 {
+				t.Fatalf("input_tokens = %v, want 10", in)
+			}
+		}
+	}
+}
+
+func TestClaudeStream_KeepalivePingBeforeFirstChunk(t *testing.T) {
+	// Use a very short keepalive interval so the ticker fires before any data arrives.
+	old := claudeKeepaliveInterval
+	claudeKeepaliveInterval = 10 * time.Millisecond
+	t.Cleanup(func() { claudeKeepaliveInterval = old })
+
+	sr := newSlowReader()
+	tsr := newSafeRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		claudeStreamHandler(context.Background(), tsr, sr, "m", false)
+		close(done)
+	}()
+
+	// Wait long enough for at least one ticker ping to arrive.
+	time.Sleep(80 * time.Millisecond)
+
+	body := tsr.String()
+	// We should see at least one ping event in the output.
+	if !strings.Contains(body, "event: ping") {
+		t.Fatalf("expected at least one ping before first chunk:\n%s", body)
+	}
+	// Must NOT have message_start yet (no upstream token seen).
+	if strings.Contains(body, "event: message_start") {
+		t.Fatalf("must not emit message_start before first upstream token:\n%s", body)
+	}
+
+	// Now close the reader so the handler can exit.
+	sr.Close()
+	<-done
+}
+
+func TestClaudeStream_ContextCancel_QuietExit(t *testing.T) {
+	sr := newSlowReader()
+	tsr := newSafeRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		claudeStreamHandler(ctx, tsr, sr, "m", false)
+		close(done)
+	}()
+
+	// Let a keepalive or two fire, then cancel context.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := tsr.String()
+	// Should not contain error events from cancellation.
+	// (ping events are fine, but error events are not.)
+	if strings.Contains(body, "event: error") {
+		t.Fatalf("must not emit error on context cancel:\n%s", body)
+	}
+}
+
+// =====================================================================
+// Claude I/O boundary tests
+// =====================================================================
+
+func TestClaudeStream_FinishNoTrailingNewline_EOF(t *testing.T) {
+	// Valid finish JSON without trailing newline + EOF should complete normally.
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		// Last line has NO trailing newline — bufio returns it + io.EOF
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if hasEvent(events, "error") {
+		t.Fatalf("must not emit error when finish chunk has no trailing newline:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "message_stop") {
+		t.Fatalf("expected message_stop:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "message_delta") {
+		t.Fatalf("expected message_delta:\n%s", rr.Body.String())
+	}
+}
+
+func TestClaudeStream_PartialDeltaThenReaderError(t *testing.T) {
+	// A valid content delta line followed immediately by a non-EOF reader error.
+	// The delta should be emitted, then the error event should follow.
+	er := &errorReader{
+		data: `data: {"choices":[{"delta":{"content":"partial delta"},"finish_reason":null}]}` + "\n\n",
+	}
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, er, "m", false)
+	body := rr.Body.String()
+	// The partial delta content should be present
+	if !strings.Contains(body, "partial delta") {
+		t.Fatalf("partial delta must be emitted before error:\n%s", body)
+	}
+	// And then an error event
+	events := parseSSEEvents(t, body)
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event after partial delta:\n%s", body)
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta on reader error:\n%s", body)
+	}
+}
+
+// =====================================================================
+// Responses stream handler tests
+// =====================================================================
+
+func TestResponsesStream_PartialEOF_ResponseFailed(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed on partial EOF:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on partial EOF:\n%s", rr.Body.String())
+	}
+	// Verify status=failed in the response.failed payload
+	for _, e := range events {
+		if e.Name == "response.failed" {
+			r, _ := e.Data["response"].(map[string]any)
+			if r["status"] != "failed" {
+				t.Fatalf("response.failed status = %#v, want failed", r["status"])
+			}
+			errObj, _ := r["error"].(map[string]any)
+			if errObj == nil {
+				t.Fatalf("response.failed missing error object")
+			}
+			if errObj["message"] == nil || errObj["message"] == "" {
+				t.Fatalf("response.failed error message empty")
+			}
+		}
+	}
+}
+
+func TestResponsesStream_InBandError_ResponseFailed(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}`,
+		``,
+		`data: {"error":{"message":"model overloaded"}}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed on in-band error:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on in-band error:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_ReaderError_ResponseFailed(t *testing.T) {
+	er := &errorReader{
+		data: "data: {\"id\":\"r\",\"created\":1,\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+	}
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: er, Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed on reader error:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on reader error:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_DoneNoFinish_ResponseFailed(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed on [DONE] without finish:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on [DONE] without finish:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_BadJSON_ResponseFailed(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}`,
+		``,
+		`data: {not valid json}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed on bad JSON:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on bad JSON:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_NormalFinish(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hello world"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if hasEvent(events, "response.failed") {
+		t.Fatalf("must not emit response.failed on normal finish:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "response.completed") {
+		t.Fatalf("expected response.completed on normal finish:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_LengthFinish_Incomplete(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if hasEvent(events, "response.failed") {
+		t.Fatalf("must not emit response.failed on length finish:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "response.incomplete") {
+		t.Fatalf("expected response.incomplete on length finish:\n%s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on length finish:\n%s", rr.Body.String())
+	}
+}
+
+// =====================================================================
+// Responses I/O boundary tests
+// =====================================================================
+
+func TestResponsesStream_FinishNoTrailingNewline_EOF(t *testing.T) {
+	// Valid finish JSON without trailing newline + EOF should complete normally.
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		// Last line has NO trailing newline — bufio returns it + io.EOF
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if hasEvent(events, "response.failed") {
+		t.Fatalf("must not emit response.failed when finish chunk has no trailing newline:\n%s", rr.Body.String())
+	}
+	if !hasEvent(events, "response.completed") {
+		t.Fatalf("expected response.completed:\n%s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_PartialDeltaThenReaderError(t *testing.T) {
+	// A valid content delta line followed immediately by a non-EOF reader error.
+	er := &errorReader{
+		data: `data: {"id":"r","created":1,"choices":[{"delta":{"content":"partial delta"},"finish_reason":null}]}` + "\n\n",
+	}
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: er, Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	body := rr.Body.String()
+	// The partial delta should be present (as output_text.delta)
+	if !strings.Contains(body, "partial delta") {
+		t.Fatalf("partial delta must be emitted before response.failed:\n%s", body)
+	}
+	events := parseSSEEvents(t, body)
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed after partial delta:\n%s", body)
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed on reader error:\n%s", body)
+	}
+}
+
+// =====================================================================
+// Trailing error tests (finish_reason seen, then error follows)
+// =====================================================================
+
+func TestClaudeStream_FinishThenInBandError(t *testing.T) {
+	// finish_reason=stop seen, then in-band error. Must emit error, not message_stop/message_delta.
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		``,
+		`data: {"error":{"message":"overloaded after finish"}}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, io.NopCloser(strings.NewReader(upstream)), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event after finish+in-band error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta after trailing in-band error: %s", rr.Body.String())
+	}
+}
+
+func TestClaudeStream_FinishThenReaderError(t *testing.T) {
+	// finish_reason=stop seen, then non-EOF reader error. Must emit error, not message_stop/message_delta.
+	er := &errorReader{
+		data: strings.Join([]string{
+			`data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+			``,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			``,
+		}, "\n"),
+	}
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, er, "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "error") {
+		t.Fatalf("expected error event after finish+reader error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
+		t.Fatalf("must not emit message_stop/delta after trailing reader error: %s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_FinishThenInBandError(t *testing.T) {
+	// finish_reason=stop seen, then in-band error. Must emit response.failed, not response.completed.
+	// Must NOT have any output_item.done (which would carry status=completed).
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		``,
+		`data: {"error":{"message":"overloaded after finish"}}`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(upstream)), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed after finish+in-band error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed after trailing in-band error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "response.output_item.done") {
+		t.Fatalf("must not emit output_item.done before response.failed: %s", rr.Body.String())
+	}
+}
+
+func TestResponsesStream_FinishThenReaderError(t *testing.T) {
+	// finish_reason=stop seen, then non-EOF reader error.
+	er := &errorReader{
+		data: strings.Join([]string{
+			`data: {"id":"r","created":1,"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}`,
+			``,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			``,
+		}, "\n"),
+	}
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: er, Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.failed") {
+		t.Fatalf("expected response.failed after finish+reader error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "response.completed") {
+		t.Fatalf("must not emit response.completed after trailing reader error: %s", rr.Body.String())
+	}
+	if hasEvent(events, "response.output_item.done") {
+		t.Fatalf("must not emit output_item.done before response.failed: %s", rr.Body.String())
+	}
+}

--- a/stream_integrity_test.go
+++ b/stream_integrity_test.go
@@ -612,6 +612,16 @@ func TestClaudeStream_FinishThenReaderError(t *testing.T) {
 	if hasEvent(events, "message_stop") || hasEvent(events, "message_delta") {
 		t.Fatalf("must not emit message_stop/delta after trailing reader error: %s", rr.Body.String())
 	}
+	// Must not leak the raw Go transport error string.
+	for _, e := range events {
+		if e.Name == "error" {
+			errObj, _ := e.Data["error"].(map[string]any)
+			msg, _ := errObj["message"].(string)
+			if msg == "" || strings.Contains(msg, "io: read/write on closed pipe") {
+				t.Fatalf("error message must be fixed string, got %q: %s", msg, rr.Body.String())
+			}
+		}
+	}
 }
 
 func TestResponsesStream_FinishThenInBandError(t *testing.T) {
@@ -662,5 +672,16 @@ func TestResponsesStream_FinishThenReaderError(t *testing.T) {
 	}
 	if hasEvent(events, "response.output_item.done") {
 		t.Fatalf("must not emit output_item.done before response.failed: %s", rr.Body.String())
+	}
+	// Must not leak the raw Go transport error string.
+	for _, e := range events {
+		if e.Name == "response.failed" {
+			resp, _ := e.Data["response"].(map[string]any)
+			errObj, _ := resp["error"].(map[string]any)
+			msg, _ := errObj["message"].(string)
+			if msg == "" || strings.Contains(msg, "io: read/write on closed pipe") {
+				t.Fatalf("error message must be fixed string, got %q: %s", msg, rr.Body.String())
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes 19 audited protocol compatibility issues across all three request/response adapters, plus a public-tier free-model routing fix.

## Stream integrity
- Upstream stream errors, abnormal EOF, missing `finish_reason`, malformed JSON, and in-band errors no longer masquerade as successful `end_turn`/`stop`.
- Claude streams emit `event: error`; Responses streams emit `response.failed`; length truncation still yields `response.incomplete`.
- Claude keepalive pings (15s default) can fire before the first upstream token.
- Single-writer SSE architecture: reader goroutine feeds a channel; only the handler goroutine writes `ResponseWriter`.

## Native Anthropic decoding
- Strict SSE lifecycle validation: exactly one `message_start`, valid block lifecycle, non-empty stop reason, and `message_stop` required.
- Ordered content blocks preserved by numeric index (`text`/`thinking`/`tool_use`).
- Supports `text_delta`, `thinking_delta`, `signature_delta`, `input_json_delta`, `redacted_thinking.data`, cumulative usage snapshot merging.
- Private `_opencode2api_anthropic_content` field preserves ordered blocks for Claude roundtrip; stripped from public Chat/Responses payloads.
- Deterministic response-ID normalization for `chatcmpl-`/`resp_`/`msg_` prefixes.
- Typed `anthropicProtocolError` preserves Anthropic type/message; transport and build errors return generic `upstream_error` without leaking `err.Error()`.

## Request compatibility
- `/v1/responses` `tool_result`: `collectFunctionOutputs` collects `tool_result`; `normalizeToolResultOutput` handles content string/array/text-blocks; `is_error` prefix is order-independent and baked into the collected map; empty string is a legitimate output (map presence distinguishes missing); output-before-call no longer creates a leading duplicate tool message.
- Anthropic `document` and Responses `input_file` map to structured Chat `file` parts; malformed items return protocol-shaped 400 instead of text leak.
- Structure-aware validators: Claude document validation inspects message content and `tool_result.content` only; Responses file validation inspects top-level `input_file` and message content only — never tool arguments, nested `tool_use.input`, schemas, or arbitrary domain data.
- Temperature boundary validation: `/v1/messages` 0..1, Chat/Responses 0..2; NaN/Inf rejected; protocol-shaped JSON 400 before upstream call or SSE.
- `cache_control` counted (including tool-level field) but not implemented; schema/input properties named `cache_control` are not falsely counted.
- `history_signature_count` logs count only, never signature values.

## Public free-model routing
- `mapPublicToFreeModel` downgrades paid model IDs to `-free` variants for keyless public-tier requests so `deepseek-v4-flash` resolves to `deepseek-v4-flash-free`; keyed tiers keep the exact requested model.

## Test plan
- [x] `gofmt -l` clean
- [x] `git diff --check` clean
- [x] `go test ./... -count=1` — 271 pass, 0 fail
- [x] `go test ./... -count=20` — pass
- [x] `go test -race ./... -count=1` — pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Linux/386 `go test -c` — pass