### PR TITLE
fix: translate /v1/responses text.format into valid upstream response_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `/v1/responses` `text` parameter being forwarded verbatim as upstream `response_format`. The Responses API `text` nests `type` inside `format` (`{format:{type:...}, verbosity:...}`), but upstream providers require a top-level `type` in `response_format`, causing `400 response_format: missing field type`. Added `convertResponsesTextToResponseFormat` to translate `text.format` into a valid Chat Completions `response_format` (`text` / `json_object` / `json_schema`), and drop the field entirely when it cannot be represented (unknown type, missing required `json_schema` fields, non-object `text`, or verbosity-only) so the proxy never forwards a malformed `response_format` and never surfaces a 400 for this case. Verified against the real upstream and end-to-end through the proxy.
+
 ## v0.4.1
 
 - Add `stop_sequence` field to non-streaming Claude responses, streaming `message_start`, and streaming `message_delta` so Claude Code sees `"stop_sequence": null` consistently, matching the Anthropic Messages API contract.

--- a/docs/responses-compatibility-analysis.md
+++ b/docs/responses-compatibility-analysis.md
@@ -344,7 +344,7 @@
 
 | 字段 | 类型 | JSON tag | 上游映射 |
 |------|------|----------|---------|
-| `Text` | `any` | `text` | `extra_body.response_format` |
+| `Text` | `any` | `text` | `extra_body.response_format`（经 `convertResponsesTextToResponseFormat` 从 Responses `text.format` 翻译为 Chat `response_format`） |
 | `Truncation` | `string` | `truncation` | `extra_body.truncation` |
 | `ServiceTier` | `string` | `service_tier` | `extra_body.service_tier` |
 | `PromptCacheKey` | `string` | `prompt_cache_key` | `extra_body.prompt_cache_key` |
@@ -373,10 +373,40 @@
 | 请求字段缺失 (6个) | ✅ 已修复 | 结构体补全并接入上游 |
 | 响应回显不完整 (14个) | ✅ 已修复 | applyResponsesRequestEcho 补全 |
 | reasoning 只支持 effort | ✅ 部分修复 | 新增 summary/mode 解析和回显；context/generate_summary 仍缺失 |
-| Structured Outputs (text.format) | ⚠️ 架构性限制 | 字段已解析并透传 extra_body，但上游 Chat Completions 对 response_format 的支持取决于模型 |
+| Structured Outputs (text.format) | ✅ 已修复 | `text.format` 翻译为合法 `response_format`（`type` 顶层必填），无法翻译时静默丢弃，不再触发上游 400 |
 | 服务器端工具执行 | ⚠️ 架构性限制 | 返回 400 告知不支持；Chat Completions 无 server-side tools 对应物 |
 | response.queued 事件 | ⚠️ 低优先级 | 大部分客户端不依赖 |
 | response.output_text.annotation.added | ⚠️ 低优先级 | 注释功能极少使用 |
+
+### 9.6 text.format 翻译为合法 response_format（修复上游 400）
+
+**问题**：`responsesHandler` 把 Responses API 的 `text` 参数**原样透传**为上游 `response_format`。
+但 Responses API 的 `text` 是 `{format:{type:...}, verbosity:...}` 结构，`type` 位于 `format` 内部；
+而上游 Console provider（Chat Completions 兼容）要求 `response_format` **顶层必须有 `type`** 字段（判别联合体）。
+于是上游收到 `{"response_format":{"format":{"type":"json_object"}}}`，serde 反序列化失败，返回：
+
+```
+Error from provider (Console): Upstream request failed: [invalid_request_error] Failed to deserialize the JSON body into the target type: response_format: missing field `type`
+```
+
+**修复**：新增 `convertResponsesTextToResponseFormat`，把 `text.format` 翻译为合法 Chat `response_format`：
+
+| Responses `text.format` | 翻译后的 `response_format` |
+|------|------|
+| `{"type":"text"}` | `{"type":"text"}` |
+| `{"type":"json_object"}` | `{"type":"json_object"}` |
+| `{"type":"json_schema", name, description, schema, strict}` | `{"type":"json_schema","json_schema":{name, description, schema, strict}}` |
+
+无法表达的情况（未知类型、`json_schema` 缺 `name`/`schema`、`text` 非对象、只有 `verbosity`）→ 返回 `nil`，
+**静默丢弃 `response_format`**，绝不发送畸形对象，遵循"不返回 400 / 不兼容就忽略"原则。
+`text.verbosity` 在 Chat 无对应物，不转发。
+
+**验证**：对真实上游 `https://opencode.ai/zen/v1/chat/completions`（经 SOCKS5）实测：
+- 修复前形态（透传 `text`）→ 400 `response_format: missing field type`（复现用户报告错误）
+- 修复后形态 `{"type":"json_object"}` / `{"type":"json_schema",...}` / `{"type":"text"}` → 全部 200
+- 端到端通过修复后的代理二进制请求 `/v1/responses`（json_object / json_schema / 无 text）→ 全部 200 并返回合法 JSON
+
+**新增测试**：`response_format_translation_test.go`（7 个用例：json_object、text、json_schema、verbosity 不泄漏、不可翻译时丢弃、无 text 不变、响应回显保持原样）。
 
 **新增测试**：4 个（`TestResponsesUnsupportedToolType_Returns400`、`TestResponsesStream_RefusalDelta`、`TestResponsesInclude_EncryptedContentOnlyWhenRequested`、`TestResponsesEcho_MissingFieldsAreEchoed`）。
 

--- a/main.go
+++ b/main.go
@@ -4609,6 +4609,56 @@ func convertResponsesTools(tools []ResponsesTool) []Tool {
 	return converted
 }
 
+// convertResponsesTextToResponseFormat translates the Responses API `text`
+// parameter ({format:{type:...}, verbosity:...}) into the Chat Completions
+// `response_format` shape ({type:...}) that upstream providers require.
+//
+// Returns nil when no representable format can be built (unknown type,
+// missing required json_schema fields, or a non-object text value) so the
+// caller can omit response_format instead of sending a malformed object that
+// upstream would reject with a 400.
+func convertResponsesTextToResponseFormat(text any) any {
+	obj, ok := text.(map[string]any)
+	if !ok {
+		return nil
+	}
+	format, ok := obj["format"].(map[string]any)
+	if !ok {
+		// Only verbosity was provided (no format) — nothing to map.
+		return nil
+	}
+	typ, _ := format["type"].(string)
+	switch typ {
+	case "text", "json_object":
+		return map[string]any{"type": typ}
+	case "json_schema":
+		jsonSchema := map[string]any{}
+		if name, ok := format["name"].(string); ok && name != "" {
+			jsonSchema["name"] = name
+		}
+		if desc, ok := format["description"].(string); ok {
+			jsonSchema["description"] = desc
+		}
+		if schema, ok := format["schema"]; ok {
+			jsonSchema["schema"] = schema
+		}
+		if strict, ok := format["strict"]; ok {
+			jsonSchema["strict"] = strict
+		}
+		// name and schema are required by both APIs; without them upstream
+		// would reject the object, so drop the format entirely.
+		if _, hasName := jsonSchema["name"]; !hasName {
+			return nil
+		}
+		if _, hasSchema := jsonSchema["schema"]; !hasSchema {
+			return nil
+		}
+		return map[string]any{"type": "json_schema", "json_schema": jsonSchema}
+	default:
+		return nil
+	}
+}
+
 func responsesToolFunction(tool ResponsesTool) (ToolFunction, bool) {
 	switch tool.Type {
 	case "function":
@@ -5457,10 +5507,17 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 		chatReq.ExtraBody["user"] = respReq.User
 	}
 	if respReq.Text != nil {
-		if chatReq.ExtraBody == nil {
-			chatReq.ExtraBody = map[string]any{}
+		// OpenAI Responses API `text` is {format:{type:...}, verbosity:...};
+		// upstream expects Chat Completions `response_format` with a top-level
+		// `type`. Translate, and drop the field entirely when it cannot be
+		// represented (never send a malformed response_format upstream, which
+		// would surface as a 400).
+		if rf := convertResponsesTextToResponseFormat(respReq.Text); rf != nil {
+			if chatReq.ExtraBody == nil {
+				chatReq.ExtraBody = map[string]any{}
+			}
+			chatReq.ExtraBody["response_format"] = rf
 		}
-		chatReq.ExtraBody["response_format"] = respReq.Text
 	}
 	if respReq.Truncation != "" {
 		if chatReq.ExtraBody == nil {

--- a/response_format_translation_test.go
+++ b/response_format_translation_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sendResponsesWithText issues a /v1/responses request carrying the given
+// `text` parameter and returns the upstream chat payload the proxy built.
+func sendResponsesWithText(t *testing.T, textJSON string) map[string]any {
+	t.Helper()
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	var reqBody string
+	if textJSON == "" {
+		reqBody = `{"model":"primary-model","input":"hello"}`
+	} else {
+		reqBody = `{"model":"primary-model","input":"hello","text":` + textJSON + `}`
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(transport.requestPayloads) != 1 {
+		t.Fatalf("upstream payloads=%d, want 1", len(transport.requestPayloads))
+	}
+	return transport.requestPayloads[0]
+}
+
+// TestResponsesTextFormat_JsonObject verifies the Responses API
+// `text.format.type=json_object` is translated into the Chat Completions
+// `response_format` with a top-level `type` (which upstream providers require).
+func TestResponsesTextFormat_JsonObject(t *testing.T) {
+	payload := sendResponsesWithText(t, `{"format":{"type":"json_object"}}`)
+	rf, ok := payload["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format missing/not object: %#v", payload["response_format"])
+	}
+	if rf["type"] != "json_object" {
+		t.Fatalf("response_format.type = %#v, want json_object", rf["type"])
+	}
+	if len(rf) != 1 {
+		t.Fatalf("response_format should contain only type, got %#v", rf)
+	}
+}
+
+// TestResponsesTextFormat_Text verifies `text.format.type=text` maps to
+// `response_format: {"type":"text"}`.
+func TestResponsesTextFormat_Text(t *testing.T) {
+	payload := sendResponsesWithText(t, `{"format":{"type":"text"}}`)
+	rf, ok := payload["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format missing/not object: %#v", payload["response_format"])
+	}
+	if rf["type"] != "text" {
+		t.Fatalf("response_format.type = %#v, want text", rf["type"])
+	}
+}
+
+// TestResponsesTextFormat_JsonSchema verifies the Responses API
+// `text.format` (json_schema) is translated into the Chat Completions
+// `response_format.json_schema` nested shape with all supported fields.
+func TestResponsesTextFormat_JsonSchema(t *testing.T) {
+	payload := sendResponsesWithText(t, `{"format":{
+		"type":"json_schema",
+		"name":"math_response",
+		"description":"a math answer",
+		"strict":true,
+		"schema":{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}
+	}}`)
+	rf, ok := payload["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format missing/not object: %#v", payload["response_format"])
+	}
+	if rf["type"] != "json_schema" {
+		t.Fatalf("response_format.type = %#v, want json_schema", rf["type"])
+	}
+	js, ok := rf["json_schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format.json_schema missing: %#v", rf)
+	}
+	if js["name"] != "math_response" {
+		t.Errorf("json_schema.name = %#v, want math_response", js["name"])
+	}
+	if js["description"] != "a math answer" {
+		t.Errorf("json_schema.description = %#v", js["description"])
+	}
+	if js["strict"] != true {
+		t.Errorf("json_schema.strict = %#v, want true", js["strict"])
+	}
+	if _, ok := js["schema"]; !ok {
+		t.Errorf("json_schema.schema missing: %#v", js)
+	}
+	// The raw Responses format object must not leak into response_format.
+	if _, leaked := rf["format"]; leaked {
+		t.Errorf("response_format must not contain Responses-style `format` key: %#v", rf)
+	}
+}
+
+// TestResponsesTextFormat_NoLeakOfVerbosity verifies `text.verbosity` is NOT
+// forwarded into response_format (it has no Chat Completions equivalent).
+func TestResponsesTextFormat_NoLeakOfVerbosity(t *testing.T) {
+	payload := sendResponsesWithText(t, `{"format":{"type":"json_object"},"verbosity":"high"}`)
+	rf, _ := payload["response_format"].(map[string]any)
+	if _, leaked := rf["verbosity"]; leaked {
+		t.Fatalf("verbosity must not leak into response_format: %#v", rf)
+	}
+	if rf["type"] != "json_object" {
+		t.Fatalf("response_format.type = %#v, want json_object", rf["type"])
+	}
+}
+
+// TestResponsesTextFormat_DroppedWhenUntranslatable verifies malformed or
+// untranslatable `text` values are silently dropped rather than forwarded as
+// a malformed response_format (which upstream rejects with 400).
+func TestResponsesTextFormat_DroppedWhenUntranslatable(t *testing.T) {
+	cases := []string{
+		`{"verbosity":"high"}`,              // format absent
+		`{"format":{"type":"json_schema"}}`, // json_schema without name/schema
+		`{"format":{"type":"weird"}}`,       // unknown format type
+		`"high"`,                            // text as a plain string
+		`[]`,                                // non-object
+	}
+	for _, tc := range cases {
+		payload := sendResponsesWithText(t, tc)
+		if _, ok := payload["response_format"]; ok {
+			t.Errorf("text=%s: response_format must be dropped, got %#v", tc, payload["response_format"])
+		}
+	}
+}
+
+// TestResponsesTextFormat_NoTextStillSendsUpstream verifies a request without
+// the text parameter is unchanged (no response_format at all).
+func TestResponsesTextFormat_NoTextStillSendsUpstream(t *testing.T) {
+	payload := sendResponsesWithText(t, "")
+	if _, ok := payload["response_format"]; ok {
+		t.Fatalf("no text param must not add response_format: %#v", payload["response_format"])
+	}
+}
+
+// TestResponsesTextFormat_ResponseEchoKeepsOriginal verifies the response
+// body still echoes the client's original `text` object as-is (client-facing
+// echo is independent of the upstream translation).
+func TestResponsesTextFormat_ResponseEchoKeepsOriginal(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   okChatBody(),
+	}})
+	reqBody := `{"model":"primary-model","input":"hello","text":{"format":{"type":"json_object"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	text, ok := resp["text"].(map[string]any)
+	if !ok {
+		t.Fatalf("response text missing/not object: %#v", resp["text"])
+	}
+	format, ok := text["format"].(map[string]any)
+	if !ok || format["type"] != "json_object" {
+		t.Fatalf("response text echo changed: %#v", resp["text"])
+	}
+	// Upstream payload must still use the translated shape.
+	payload := transport.requestPayloads[0]
+	rf, _ := payload["response_format"].(map[string]any)
+	if rf == nil || rf["type"] != "json_object" {
+		t.Fatalf("upstream response_format = %#v, want translated json_object", payload["response_format"])
+	}
+}


### PR DESCRIPTION
## 背景

`/v1/responses` 请求携带 `text` 参数时，上游返回：

```
Error from provider (Console): Upstream request failed: [invalid_request_error] Failed to deserialize the JSON body into the target type: response_format: missing field `type`
```

## 根因

OpenAI Responses API 的 `text` 参数结构是 `{format:{type:...}, verbosity:...}`，`type` 位于 `format` 内部：

```json
{
  "text": {
    "format": { "type": "json_object" }
  }
}
```

但上游 Console provider 接受的是 Chat Completions 风格的 `response_format`，要求**顶层必须有 `type`** 字段（判别联合体）：

```json
{
  "response_format": { "type": "json_object" }
}
```

修复前的 `responsesHandler` 把 `respReq.Text` **原样透传**为 `response_format`：

```go
chatReq.ExtraBody["response_format"] = respReq.Text
```

于是上游收到 `{"response_format":{"format":{"type":"json_object"}}}`，顶层缺少 `type`。opencode Console 网关不做转换、原样转发给上游模型服务商；上游使用 Rust serde 严格反序列化请求体，`type` 是必填字段，缺失即返回 400 `response_format: missing field type`。

## 调查过程

使用了多个子代理并行调查官方文档，并直接请求真实上游验证：

1. **Responses API `text` 参数权威结构**（OpenAI OpenAPI 规范 + 官方 API reference）：
   - `text = {format, verbosity}`
   - `text.format.type`：`"text"` | `"json_object"` | `"json_schema"`
   - `json_schema` 需要 `name`、`schema`，可选 `description`、`strict`

2. **Chat Completions `response_format` 权威结构**（OpenAI OpenAPI 规范）：
   - `discriminator: {propertyName: type}`
   - `type` 必填：`"text"` | `"json_object"` | `"json_schema"`
   - `json_schema` 形态需要顶层 `type` + 嵌套 `json_schema` 对象

3. **真实上游复现**（经 SOCKS5 代理直连 `https://opencode.ai/zen/v1/chat/completions`，模型 `deepseek-v4-flash-free`，public auth）：
   - 修复前形态 `response_format={"format":{"type":"json_object"}}` → 400 `missing field type`
   - 修复后形态 `{"type":"json_object"}` / `{"type":"json_schema",...}` / `{"type":"text"}` → 全部 200 正常返回

## 修复内容

新增 `convertResponsesTextToResponseFormat`，把 Responses API 的 `text.format` 翻译成合法 Chat Completions `response_format`：

| Responses `text.format` | 翻译后的 `response_format` |
|------|------|
| `{"type":"text"}` | `{"type":"text"}` |
| `{"type":"json_object"}` | `{"type":"json_object"}` |
| `{"type":"json_schema", name, description, schema, strict}` | `{"type":"json_schema","json_schema":{name, description, schema, strict}}` |

无法表达的情况（未知类型、`json_schema` 缺 `name`/`schema`、`text` 非对象、只有 `verbosity`）→ 返回 `nil`，**静默丢弃 `response_format`**，绝不发送畸形对象。

遵循原则：
- **不返回 400**：发送给上游的 `response_format` 永远是完整合法结构（`type` 必填），或者干脆省略
- **不兼容就忽略**：无法翻译成合法结构时静默丢弃，而不是报错或传坏数据

流式和非流式请求共用同一段 `chatReq.ExtraBody` 构造逻辑，一个修复同时覆盖两条路径。

## 验证

- 新增 `response_format_translation_test.go`（7 个用例）：
  - `json_object` 翻译正确
  - `text` 翻译正确
  - `json_schema` 翻译正确且不泄漏 Responses 的 `format` 字段
  - `verbosity` 不会泄漏进 `response_format`
  - 不可翻译的 `text` 被丢弃（未知类型、缺 name/schema、字符串 text 等）
  - 无 `text` 参数时不添加 `response_format`
  - 响应回显保持客户端原始 `text` 对象

- 真实上游对比（经 SOCKS5，`deepseek-v4-flash-free`）：
  - 修复前形态 → ❌ 400 `missing field type`
  - 修复后 `json_object` / `json_schema` / `text` → ✅ 全部 200

- 端到端通过修复后的代理二进制（`/v1/responses`）：
  - `text.format={"type":"json_object"}` → ✅ 200，返回 `{"ok": true}`
  - `text.format={"type":"json_schema",...}` → ✅ 200，返回符合 schema 的 JSON
  - 无 `text` 基线 → ✅ 200

- 完整测试：`go build`、`go vet ./...`、`go test ./... -count=1` 全部通过。
