### PR TITLE
fix: ensure Responses cached_tokens is always present

### DIFF
--- a/internal/app/protocol_regression_test.go
+++ b/internal/app/protocol_regression_test.go
@@ -655,3 +655,96 @@ func TestClaudeCodePayloadDropsContextManagementAndCacheControl(t *testing.T) {
 		t.Fatalf("summary missing cache_control_blocks: %#v", summary)
 	}
 }
+
+func TestResponsesStreamUsageAddsCachedTokensWhenPromptDetailsLackIt(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		details    string
+		wantCached float64
+		wantText   float64
+	}{
+		{"details with cached tokens", `{"cached_tokens":7,"text_tokens":10}`, 7, 10},
+		{"no cached tokens", `{"text_tokens":10}`, 0, 10},
+		{"without prompt details", "", 0, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			usageLine := `"prompt_tokens_details":` + tt.details
+			if tt.details == "" {
+				usageLine = ""
+			}
+			chunk := `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5`
+			if usageLine != "" {
+				usageLine = "," + usageLine
+			}
+			chunk += usageLine + `}}`
+			upstream := strings.Join([]string{
+				`data: {"id":"r","created":1,"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}`,
+				``,
+				chunk,
+				``,
+				`data: [DONE]`,
+				``,
+			}, "\n")
+			rr := httptest.NewRecorder()
+			responsesStreamHandler(rr, nil, &http.Response{Body: io.NopCloser(strings.NewReader(upstream))}, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+			for _, event := range parseSSEEvents(t, rr.Body.String()) {
+				if event.Name != "response.completed" {
+					continue
+				}
+				response, _ := event.Data["response"].(map[string]any)
+				usage, _ := response["usage"].(map[string]any)
+				details, _ := usage["input_tokens_details"].(map[string]any)
+				if int(details["cached_tokens"].(float64)) != int(tt.wantCached) {
+					t.Fatalf("cached_tokens = %v, want %v:\n%s", details["cached_tokens"], tt.wantCached, rr.Body.String())
+				}
+				if tt.wantText == 0 {
+					if _, ok := details["text_tokens"]; ok {
+						t.Fatalf("unexpected text_tokens = %v", details["text_tokens"])
+					}
+				} else if int(details["text_tokens"].(float64)) != int(tt.wantText) {
+					t.Fatalf("text_tokens = %v, want %v", details["text_tokens"], tt.wantText)
+				}
+				return
+			}
+			t.Fatalf("response.completed not found:\n%s", rr.Body.String())
+		})
+	}
+}
+
+func TestResponsesConvertChatUsageAddsCachedTokensWhenPromptDetailsLackIt(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		details    string
+		wantCached float64
+		wantText   float64
+	}{
+		{"details with cached tokens", `{"cached_tokens":7,"text_tokens":10}`, 7, 10},
+		{"no cached tokens", `{"text_tokens":10}`, 0, 10},
+		{"without prompt details", "", 0, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := `"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5`
+			if tt.details != "" {
+				usage += `,"prompt_tokens_details":` + tt.details
+			}
+			usage += `}`
+			in := `{"id":"r","created":1,"choices":[{"finish_reason":"stop","message":{"content":"ok"}}],` + usage + `}`
+			var got map[string]any
+			if err := json.Unmarshal(convertChatToResponses([]byte(in), "m", false, nil, nil, nil), &got); err != nil {
+				t.Fatal(err)
+			}
+			respUsage, _ := got["usage"].(map[string]any)
+			details, _ := respUsage["input_tokens_details"].(map[string]any)
+			if int(details["cached_tokens"].(float64)) != int(tt.wantCached) {
+				t.Fatalf("cached_tokens = %v, want %v", details["cached_tokens"], tt.wantCached)
+			}
+			if tt.wantText == 0 {
+				if _, ok := details["text_tokens"]; ok {
+					t.Fatalf("unexpected text_tokens = %v", details["text_tokens"])
+				}
+			} else if int(details["text_tokens"].(float64)) != int(tt.wantText) {
+				t.Fatalf("text_tokens = %v, want %v", details["text_tokens"], tt.wantText)
+			}
+		})
+	}
+}

--- a/internal/app/responses.go
+++ b/internal/app/responses.go
@@ -1254,6 +1254,17 @@ func responsesHandler(w http.ResponseWriter, r *http.Request) {
 
 // ======================== Responses Stream Handler ========================
 
+func responsesInputTokensDetails(details any) map[string]any {
+	if m, ok := details.(map[string]any); ok {
+		if cached, ok := m["cached_tokens"]; ok && cached != nil {
+			return m
+		}
+		m["cached_tokens"] = 0
+		return m
+	}
+	return map[string]any{"cached_tokens": 0}
+}
+
 func responsesStreamHandler(w http.ResponseWriter, r *http.Request, resp *http.Response, model string, _ string, wantReasoning bool, tools []ResponsesTool, toolChoice any, originalReq ResponsesAPIRequest) {
 	ctx := context.Background()
 	if r != nil {
@@ -1902,11 +1913,7 @@ loop:
 		if v, ok := totalUsage["prompt_tokens"]; ok {
 			usage["input_tokens"] = v
 		}
-		if v, ok := totalUsage["prompt_tokens_details"]; ok {
-			usage["input_tokens_details"] = v
-		} else {
-			usage["input_tokens_details"] = map[string]any{"cached_tokens": 0}
-		}
+		usage["input_tokens_details"] = responsesInputTokensDetails(totalUsage["prompt_tokens_details"])
 		if v, ok := totalUsage["completion_tokens"]; ok {
 			usage["output_tokens"] = v
 		}
@@ -2039,11 +2046,7 @@ func convertChatToResponses(chatBody []byte, model string, wantReasoning bool, t
 		if v, ok := chat.Usage["prompt_tokens"]; ok {
 			usage["input_tokens"] = v
 		}
-		if v, ok := chat.Usage["prompt_tokens_details"]; ok {
-			usage["input_tokens_details"] = v
-		} else {
-			usage["input_tokens_details"] = map[string]any{"cached_tokens": 0}
-		}
+		usage["input_tokens_details"] = responsesInputTokensDetails(chat.Usage["prompt_tokens_details"])
 		if v, ok := chat.Usage["completion_tokens"]; ok {
 			usage["output_tokens"] = v
 		}


### PR DESCRIPTION
Fixes #6

## Root cause

Codex parses `response.completed` with a strict Rust serde schema: if `usage.input_tokens_details` is present, `cached_tokens` is required. The issue's GLM -> sub2api -> opencode2api path sends a chat completions `prompt_tokens_details` object that exists but does not include `cached_tokens`. opencode2api forwarded it verbatim, so Codex rejected the event and disconnected the stream.

## Change

Added `responsesInputTokensDetails`, used by both the streaming `response.completed` path and the non-stream `convertChatToResponses` path:

- preserve an existing non-nil `cached_tokens`;
- otherwise add `cached_tokens: 0` to the existing details;
- keep the existing fallback `{"cached_tokens":0}` when details are absent or not a map.

## Verification

- `go test ./...` passes.
- Added regression tests for stream and non-stream responses paths covering:
  - details present without `cached_tokens` -> padded with 0;
  - existing `cached_tokens` preserved;
  - details absent -> `{"cached_tokens":0}`.
- Independent subagent verification ran a real HTTP handler against a fake upstream stream with `prompt_tokens_details` but no `cached_tokens`; the resulting SSE contains `response.completed` with `usage.input_tokens_details.cached_tokens == 0` while preserving `text_tokens`.
