### PR TITLE
fix: convert DeepSeek DSML/Qwen XML tool calls to standard OpenAI tool_calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix DeepSeek/Qwen models that emit raw DSML/XML tool-call markup (for example `<｜DSML｜tool_calls>`, `<|DSML|tool_calls>`, `<tool_calls>`, and `<tool_call>`) by converting it to standard OpenAI `tool_calls` before it reaches Chat/Claude/Responses clients. Non-streaming responses are normalized in `callOpenCodeAPI`; streaming responses are wrapped by `callOpenCodeAPIStream` so all three downstream protocols share one conversion layer. Native `tool_calls`, `usage`, `reasoning_content`, `finish_reason`, and `[DONE]` semantics are preserved.
+
 ## v0.4.3
 
 - Fix `cache_control` counting so signature fields are not treated as cacheable message content, and ensure Responses `cached_tokens` remains present in Claude usage translation.

--- a/internal/app/opencode.go
+++ b/internal/app/opencode.go
@@ -380,6 +380,7 @@ func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, a
 				}
 				b = converted
 			}
+			b = convertRawToolCallsInBody(b)
 			log.Info("upstream_attempt",
 				"try_model", modelID,
 				"surface", surface,
@@ -562,7 +563,7 @@ func callOpenCodeAPIStream(ctx context.Context, upstreamBody []byte, modelID str
 				"final_status", resp.StatusCode,
 				"fallback_used", false,
 			)
-			return resp.Body, resp.StatusCode, resp.Header, nil
+			return wrapRawSSE(resp.Body), resp.StatusCode, resp.Header, nil
 		}
 		errBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()

--- a/internal/app/raw_tool_calls.go
+++ b/internal/app/raw_tool_calls.go
@@ -1,0 +1,961 @@
+package app
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"html"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+const (
+	dsmlBar             = "\uff5c"
+	dsmlOpen            = "<" + dsmlBar + "DSML" + dsmlBar + "tool_calls>"
+	dsmlClose           = "</" + dsmlBar + "DSML" + dsmlBar + "tool_calls>"
+	dsmlInvoke          = "<" + dsmlBar + "DSML" + dsmlBar + "invoke"
+	dsmlInvokeEnd       = "</" + dsmlBar + "DSML" + dsmlBar + "invoke>"
+	dsmlParam           = "<" + dsmlBar + "DSML" + dsmlBar + "parameter "
+	dsmlParamEnd        = "</" + dsmlBar + "DSML" + dsmlBar + "parameter>"
+	dsmlOpenAlt         = "<|DSML|tool_calls>"
+	dsmlCloseAlt        = "</|DSML|tool_calls>"
+	dsmlOpenColon       = "<DSML>tool_calls>"
+	dsmlCloseColon      = "</DSML:tool_calls>"
+	dsmlCloseColonAlt   = "</DSML>tool_calls>"
+	dsmlCloseColonSpace = "</DSML tool_calls>"
+
+	rawToolOpen     = "<tool_calls>"
+	rawToolClose    = "</tool_calls>"
+	rawQwenOpen     = "<tool_call>"
+	rawQwenClose    = "</tool_call>"
+	rawFunctionOpen = "<function="
+	rawFunctionEnd  = "</function>"
+)
+
+var rawToolOpenMarkers = []string{
+	dsmlOpen,
+	dsmlOpenAlt,
+	dsmlOpenColon,
+	rawToolOpen,
+	rawQwenOpen,
+	rawFunctionOpen,
+}
+
+var rawToolFragmentMarkers = []string{
+	dsmlOpen,
+	dsmlClose,
+	dsmlOpenAlt,
+	dsmlCloseAlt,
+	"<" + dsmlBar + "DSML" + dsmlBar + "invoke",
+	"</" + dsmlBar + "DSML" + dsmlBar + "invoke>",
+	"<" + dsmlBar + "DSML" + dsmlBar + "parameter",
+	"</" + dsmlBar + "DSML" + dsmlBar + "parameter>",
+	"<DSML:",
+	"</DSML:",
+	dsmlCloseColonAlt,
+	dsmlCloseColonSpace,
+	"<|DSML|invoke",
+	"<|DSML|parameter",
+	"</|DSML|invoke",
+	"</|DSML|parameter",
+	"</|DSML|tool_calls",
+	rawToolOpen,
+	rawToolClose,
+	rawQwenOpen,
+	rawQwenClose,
+	rawFunctionOpen,
+	rawFunctionEnd,
+}
+
+// normalizeRawToolCalls converts the accepted raw marker variants into the
+// canonical full-width DSML form used by parseRawToolCalls.
+func normalizeRawToolCalls(text string) string {
+	text = strings.ReplaceAll(text, dsmlOpenAlt, dsmlOpen)
+	text = strings.ReplaceAll(text, dsmlCloseAlt, dsmlClose)
+	text = strings.ReplaceAll(text, "<|DSML|invoke", "<"+dsmlBar+"DSML"+dsmlBar+"invoke")
+	text = strings.ReplaceAll(text, "<|DSML|parameter", "<"+dsmlBar+"DSML"+dsmlBar+"parameter")
+	text = strings.ReplaceAll(text, "</|DSML|invoke", "</"+dsmlBar+"DSML"+dsmlBar+"invoke")
+	text = strings.ReplaceAll(text, "</|DSML|parameter", "</"+dsmlBar+"DSML"+dsmlBar+"parameter")
+
+	if strings.Contains(text, dsmlOpenColon) {
+		text = strings.Replace(text, dsmlOpenColon, dsmlOpen, 1)
+		text = strings.ReplaceAll(text, dsmlCloseColon, dsmlClose)
+		text = strings.ReplaceAll(text, dsmlCloseColonAlt, dsmlClose)
+		text = strings.ReplaceAll(text, dsmlCloseColonSpace, dsmlClose)
+		text = replaceDSMLColonTags(text)
+	} else if strings.Contains(text, rawToolOpen) && strings.Contains(text, rawToolClose) {
+		text = strings.Replace(text, rawToolOpen, dsmlOpen, 1)
+		text = strings.ReplaceAll(text, rawToolClose, dsmlClose)
+		text = replaceBareToolTags(text)
+	} else if strings.Contains(text, rawQwenOpen) || strings.Contains(text, rawFunctionOpen) {
+		// Qwen blocks are parsed directly and need no canonical DSML wrapper.
+		text = strings.ReplaceAll(text, "|DSML|", dsmlBar)
+	}
+	return text
+}
+
+func replaceDSMLColonTags(text string) string {
+	text = strings.ReplaceAll(text, "<DSML:invoke ", dsmlInvoke+" ")
+	text = strings.ReplaceAll(text, "</DSML:invoke>", dsmlInvokeEnd)
+	text = strings.ReplaceAll(text, "<DSML:parameter ", dsmlParam)
+	text = strings.ReplaceAll(text, "</DSML:parameter>", dsmlParamEnd)
+	return text
+}
+
+func replaceBareToolTags(text string) string {
+	text = strings.ReplaceAll(text, "<invoke ", dsmlInvoke+" ")
+	text = strings.ReplaceAll(text, "</invoke>", dsmlInvokeEnd)
+	text = strings.ReplaceAll(text, "<parameter ", dsmlParam)
+	text = strings.ReplaceAll(text, "</parameter>", dsmlParamEnd)
+	return text
+}
+
+func hasCompleteRawToolBlock(text string) bool {
+	if strings.Contains(text, dsmlOpen) && strings.Contains(text, dsmlClose) {
+		return true
+	}
+	if strings.Contains(text, dsmlOpenAlt) && strings.Contains(text, dsmlCloseAlt) {
+		return true
+	}
+	if strings.Contains(text, dsmlOpenColon) && (strings.Contains(text, dsmlCloseColon) || strings.Contains(text, dsmlCloseColonAlt) || strings.Contains(text, dsmlCloseColonSpace)) {
+		return true
+	}
+	if strings.Contains(text, rawToolOpen) && strings.Contains(text, rawToolClose) {
+		return true
+	}
+	if strings.Contains(text, rawQwenOpen) && strings.Contains(text, rawQwenClose) {
+		return true
+	}
+	if strings.Contains(text, rawFunctionOpen) && strings.Contains(text, rawFunctionEnd) {
+		return true
+	}
+	return false
+}
+
+// findRawToolStart returns the first index where raw tool markup begins. The
+// returned value is only meaningful when the text contains a complete block.
+func findRawToolStart(text string) int {
+	normalized := normalizeRawToolCalls(text)
+	idx := firstMarkerIndex(normalized, rawToolOpenMarkers)
+	if idx >= 0 {
+		return idx
+	}
+	idx = firstMarkerIndex(normalized, rawToolFragmentMarkers)
+	if idx >= 0 {
+		return idx
+	}
+	return len(text)
+}
+
+func firstMarkerIndex(text string, markers []string) int {
+	idx := -1
+	for _, marker := range markers {
+		if i := strings.Index(text, marker); i >= 0 && (idx == -1 || i < idx) {
+			idx = i
+		}
+	}
+	return idx
+}
+
+type rawToolCall struct {
+	ID       string          `json:"id"`
+	Type     string          `json:"type"`
+	Function rawToolFunction `json:"function"`
+}
+
+type rawToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+func parseRawToolCalls(text string) []rawToolCall {
+	normalized := normalizeRawToolCalls(text)
+	var calls []rawToolCall
+	calls = append(calls, parseDSMLToolCalls(normalized)...)
+	calls = append(calls, parseQwenToolCalls(normalized)...)
+	if len(calls) == 0 && hasCompleteRawToolBlock(normalized) {
+		slog.Warn("raw tool block present but could not be parsed", "text", truncateRawToolText(text))
+	}
+	return calls
+}
+
+func parseDSMLToolCalls(text string) []rawToolCall {
+	var calls []rawToolCall
+	rest := text
+	for {
+		start := strings.Index(rest, dsmlOpen)
+		if start < 0 {
+			break
+		}
+		blockStart := start + len(dsmlOpen)
+		end := strings.Index(rest[blockStart:], dsmlClose)
+		if end < 0 {
+			break
+		}
+		block := rest[blockStart : blockStart+end]
+		calls = append(calls, parseDSMLNameParameters(block)...)
+		calls = append(calls, parseDSMLInvokeParameters(block)...)
+		rest = rest[blockStart+end+len(dsmlClose):]
+	}
+	return calls
+}
+
+func parseDSMLNameParameters(block string) []rawToolCall {
+	var calls []rawToolCall
+	rest := block
+	for {
+		nameStart := strings.Index(rest, "<name>")
+		if nameStart < 0 {
+			break
+		}
+		nameEnd := strings.Index(rest[nameStart:], "</name>")
+		if nameEnd < 0 {
+			break
+		}
+		paramsStart := strings.Index(rest[nameStart+nameEnd:], "<parameters>")
+		if paramsStart < 0 {
+			break
+		}
+		paramsEnd := strings.Index(rest[nameStart+nameEnd+paramsStart:], "</parameters>")
+		if paramsEnd < 0 {
+			break
+		}
+		name := strings.TrimSpace(rest[nameStart+len("<name>") : nameStart+nameEnd])
+		args := strings.TrimSpace(rest[nameStart+nameEnd+paramsStart+len("<parameters>") : nameStart+nameEnd+paramsStart+paramsEnd])
+		if name != "" {
+			calls = append(calls, newRawToolCall(name, args))
+		}
+		rest = rest[nameStart+nameEnd+paramsStart+paramsEnd+len("</parameters>"):]
+	}
+	return calls
+}
+
+func parseDSMLInvokeParameters(block string) []rawToolCall {
+	var calls []rawToolCall
+	rest := block
+	for {
+		invokeStart := strings.Index(rest, dsmlInvoke+" ")
+		if invokeStart < 0 {
+			break
+		}
+		openEnd := strings.Index(rest[invokeStart:], ">")
+		if openEnd < 0 {
+			break
+		}
+		name := attributeValue(rest[invokeStart:invokeStart+openEnd], "name")
+		bodyStart := invokeStart + openEnd + 1
+		invokeEnd := strings.Index(rest[bodyStart:], dsmlInvokeEnd)
+		if invokeEnd < 0 {
+			break
+		}
+		if name != "" {
+			params := parseDSMLParameters(rest[bodyStart : bodyStart+invokeEnd])
+			calls = append(calls, newRawToolCall(name, string(marshalRawArguments(params))))
+		}
+		rest = rest[bodyStart+invokeEnd+len(dsmlInvokeEnd):]
+	}
+	return calls
+}
+
+func parseDSMLParameters(block string) map[string]any {
+	params := map[string]any{}
+	rest := block
+	for {
+		tag := "<" + dsmlBar + "DSML" + dsmlBar + "parameter "
+		start := strings.Index(rest, tag)
+		if start < 0 {
+			break
+		}
+		openEnd := strings.Index(rest[start:], ">")
+		if openEnd < 0 {
+			break
+		}
+		name := attributeValue(rest[start:start+openEnd], "name")
+		bodyStart := start + openEnd + 1
+		endTag := "</" + dsmlBar + "DSML" + dsmlBar + "parameter>"
+		end := strings.Index(rest[bodyStart:], endTag)
+		if end < 0 {
+			break
+		}
+		value := strings.TrimSpace(rest[bodyStart : bodyStart+end])
+		if name != "" {
+			params[name] = normalizeArgumentValue(value)
+		}
+		rest = rest[bodyStart+end+len(endTag):]
+	}
+	return params
+}
+
+func parseQwenToolCalls(text string) []rawToolCall {
+	var calls []rawToolCall
+	rest := text
+	for {
+		start := strings.Index(rest, rawQwenOpen)
+		if start < 0 {
+			break
+		}
+		bodyStart := start + len(rawQwenOpen)
+		end := strings.Index(rest[bodyStart:], rawQwenClose)
+		if end < 0 {
+			break
+		}
+		block := rest[bodyStart : bodyStart+end]
+		calls = append(calls, parseQwenNameParameters(block)...)
+		calls = append(calls, parseQwenFunctionParameters(block)...)
+		rest = rest[bodyStart+end+len(rawQwenClose):]
+	}
+	calls = append(calls, parseQwenFunctionParametersOutside(text)...)
+	return calls
+}
+
+// parseQwenFunctionParametersOutside parses <function=...> blocks that are not
+// already wrapped in <tool_call>, avoiding duplicates for the wrapped form.
+func parseQwenFunctionParametersOutside(text string) []rawToolCall {
+	var calls []rawToolCall
+	rest := text
+	for {
+		start := strings.Index(rest, rawFunctionOpen)
+		if start < 0 {
+			break
+		}
+		openEnd := strings.Index(rest[start:], ">")
+		if openEnd < 0 {
+			break
+		}
+		bodyStart := start + openEnd + 1
+		end := strings.Index(rest[bodyStart:], rawFunctionEnd)
+		if end < 0 {
+			break
+		}
+		if !insideQwenBlock(text, start) {
+			calls = append(calls, parseQwenFunctionBody(rest[start:bodyStart+end+len(rawFunctionEnd)])...)
+		}
+		rest = rest[bodyStart+end+len(rawFunctionEnd):]
+	}
+	return calls
+}
+
+func insideQwenBlock(text string, pos int) bool {
+	openAt := strings.LastIndex(text[:pos], rawQwenOpen)
+	if openAt < 0 {
+		return false
+	}
+	closeAt := strings.LastIndex(text[:pos], rawQwenClose)
+	return closeAt < openAt
+}
+
+func parseQwenNameParameters(block string) []rawToolCall {
+	name := xmlElement(block, "name")
+	if name == "" {
+		return nil
+	}
+	args := xmlElement(block, "parameters")
+	return []rawToolCall{newRawToolCall(name, args)}
+}
+
+func parseQwenFunctionParameters(text string) []rawToolCall {
+	var calls []rawToolCall
+	rest := text
+	for {
+		start := strings.Index(rest, rawFunctionOpen)
+		if start < 0 {
+			break
+		}
+		openEnd := strings.Index(rest[start:], ">")
+		if openEnd < 0 {
+			break
+		}
+		bodyStart := start + openEnd + 1
+		end := strings.Index(rest[bodyStart:], rawFunctionEnd)
+		if end < 0 {
+			break
+		}
+		calls = append(calls, parseQwenFunctionBody(rest[start:bodyStart+end+len(rawFunctionEnd)])...)
+		rest = rest[bodyStart+end+len(rawFunctionEnd):]
+	}
+	return calls
+}
+
+func parseQwenFunctionBody(block string) []rawToolCall {
+	start := strings.Index(block, rawFunctionOpen)
+	if start < 0 {
+		return nil
+	}
+	openEnd := strings.Index(block[start:], ">")
+	if openEnd < 0 {
+		return nil
+	}
+	name := strings.TrimSpace(block[start+len(rawFunctionOpen) : start+openEnd])
+	bodyStart := start + openEnd + 1
+	end := strings.Index(block[bodyStart:], rawFunctionEnd)
+	if end < 0 || name == "" {
+		return nil
+	}
+	paramRest := block[bodyStart : bodyStart+end]
+	params := map[string]any{}
+	for {
+		paramStart := strings.Index(paramRest, "<parameter=")
+		if paramStart < 0 {
+			break
+		}
+		paramOpenEnd := strings.Index(paramRest[paramStart:], ">")
+		if paramOpenEnd < 0 {
+			break
+		}
+		key := strings.TrimSpace(paramRest[paramStart+len("<parameter=") : paramStart+paramOpenEnd])
+		valueStart := paramStart + paramOpenEnd + 1
+		valueEnd := strings.Index(paramRest[valueStart:], "</parameter>")
+		if valueEnd < 0 {
+			break
+		}
+		value := strings.TrimSpace(paramRest[valueStart : valueStart+valueEnd])
+		if key != "" {
+			params[key] = normalizeArgumentValue(value)
+		}
+		paramRest = paramRest[valueStart+valueEnd+len("</parameter>"):]
+	}
+	return []rawToolCall{newRawToolCall(name, string(marshalRawArguments(params)))}
+}
+
+func xmlElement(text, tag string) string {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	start := strings.Index(text, open)
+	if start < 0 {
+		return ""
+	}
+	end := strings.Index(text[start+len(open):], close)
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(text[start+len(open) : start+len(open)+end])
+}
+
+func attributeValue(tag, key string) string {
+	prefix := key + "=\""
+	start := strings.Index(tag, prefix)
+	if start < 0 {
+		return ""
+	}
+	rest := tag[start+len(prefix):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return ""
+	}
+	return html.UnescapeString(strings.TrimSpace(rest[:end]))
+}
+
+func newRawToolCall(name, arguments string) rawToolCall {
+	id := "call_" + toolCallIDHash(name+"\x00"+arguments)
+	return rawToolCall{
+		ID:   id,
+		Type: "function",
+		Function: rawToolFunction{
+			Name:      strings.TrimSpace(name),
+			Arguments: normalizeArgumentValue(arguments),
+		},
+	}
+}
+
+func normalizeArgumentValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "{}"
+	}
+	decoded := html.UnescapeString(value)
+	var parsed any
+	if err := json.Unmarshal([]byte(decoded), &parsed); err == nil {
+		if _, ok := parsed.(map[string]any); ok {
+			b, _ := json.Marshal(parsed)
+			return string(b)
+		}
+		if _, ok := parsed.([]any); ok {
+			b, _ := json.Marshal(parsed)
+			return string(b)
+		}
+	}
+	return value
+}
+
+func marshalRawArguments(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}
+
+func toolCallIDHash(seed string) string {
+	sum := sha256Sum([]byte(seed))
+	return hex.EncodeToString(sum[:12])
+}
+
+func truncateRawToolText(text string) string {
+	if len(text) <= 800 {
+		return text
+	}
+	return text[:800]
+}
+
+// convertRawToolCallsInBody converts a non-streaming Chat response when the
+// assistant message contains a complete raw tool block and has no native
+// tool_calls. It returns the original body when conversion does not apply.
+func convertRawToolCallsInBody(body []byte) []byte {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+	converted := convertRawToolCallsInMap(raw)
+	if !converted {
+		return body
+	}
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func convertRawToolCallsInMap(body map[string]any) bool {
+	choices, ok := body["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		return false
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return false
+	}
+	msg, ok := choice["message"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if calls, exists := msg["tool_calls"]; exists && calls != nil {
+		if arr, ok := calls.([]any); ok && len(arr) > 0 {
+			return false
+		}
+	}
+	content, _ := msg["content"].(string)
+	if content == "" || !hasCompleteRawToolBlock(content) {
+		return false
+	}
+	toolCalls := parseRawToolCalls(content)
+	if len(toolCalls) == 0 {
+		return false
+	}
+	start := findRawToolStart(content)
+	prefix := strings.TrimSpace(content[:start])
+	if prefix == "" {
+		msg["content"] = nil
+	} else {
+		msg["content"] = prefix
+	}
+	msg["tool_calls"] = toolCalls
+	if fr, ok := choice["finish_reason"].(string); !ok || (fr != "tool_calls" && fr != "function_call") {
+		choice["finish_reason"] = "tool_calls"
+	}
+	return true
+}
+
+// rawSSEReader wraps an upstream Chat SSE stream and rewrites raw DSML/Qwen
+// content into standard delta.tool_calls events.
+type rawSSEReader struct {
+	src       io.ReadCloser
+	reader    *bufio.Reader
+	pending   [][]byte
+	deferred  [][]byte
+	text      strings.Builder
+	buffering bool
+	native    bool
+	converted bool
+	done      bool
+	closed    bool
+	chunkID   string
+	model     string
+	created   any
+}
+
+func wrapRawSSE(r io.ReadCloser) io.ReadCloser {
+	return &rawSSEReader{src: r, reader: bufio.NewReader(r)}
+}
+
+func (r *rawSSEReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	return r.src.Close()
+}
+
+func (r *rawSSEReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, io.EOF
+	}
+	for len(r.pending) == 0 {
+		if r.done {
+			return 0, io.EOF
+		}
+		line, err := r.reader.ReadString('\n')
+		if len(line) > 0 {
+			r.processLine(line)
+		}
+		if err != nil {
+			if err == io.EOF {
+				r.finishAtEOF()
+				r.done = true
+				if len(r.pending) == 0 {
+					return 0, io.EOF
+				}
+				break
+			}
+			r.finishAtEOF()
+			r.done = true
+			if len(r.pending) == 0 {
+				return 0, err
+			}
+			break
+		}
+	}
+	if len(r.pending) == 0 {
+		return 0, io.EOF
+	}
+	line := r.pending[0]
+	if len(p) >= len(line) {
+		r.pending = r.pending[1:]
+		return copy(p, line), nil
+	}
+	n := copy(p, line)
+	r.pending[0] = line[n:]
+	return n, nil
+}
+
+func (r *rawSSEReader) processLine(line string) {
+	if strings.TrimSpace(line) == "" {
+		if r.buffering {
+			r.deferred = append(r.deferred, []byte(line))
+		} else if !r.done {
+			r.pending = append(r.pending, []byte(line))
+		}
+		return
+	}
+	if r.native {
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	if r.done {
+		return
+	}
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "data: [DONE]" || trimmed == "[DONE]" {
+		if r.buffering {
+			r.deferred = append(r.deferred, []byte(line))
+			return
+		}
+		r.done = true
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	if !strings.HasPrefix(trimmed, "data: ") && !strings.HasPrefix(trimmed, "data:") {
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+	var chunk map[string]any
+	if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	if id, ok := chunk["id"].(string); ok && id != "" {
+		r.chunkID = id
+	}
+	if model, ok := chunk["model"].(string); ok && model != "" {
+		r.model = model
+	}
+	if v, ok := chunk["created"]; ok && v != nil {
+		r.created = v
+	}
+	choices, ok := chunk["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		if r.buffering {
+			r.deferred = append(r.deferred, []byte(line))
+		} else {
+			r.pending = append(r.pending, []byte(line))
+		}
+		return
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	delta, _ := choice["delta"].(map[string]any)
+	if r.converted {
+		if u, ok := chunk["usage"]; ok && u != nil {
+			r.pending = append(r.pending, []byte(r.makeUsageOnlyLine(chunk)))
+		}
+		return
+	}
+	if tc, ok := delta["tool_calls"].([]any); ok && len(tc) > 0 {
+		r.native = true
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	finishReason, _ := choice["finish_reason"].(string)
+	if r.buffering {
+		text := collectRawDeltaText(delta)
+		if text != "" {
+			r.text.WriteString(text)
+		}
+		if hasCompleteRawToolBlock(r.text.String()) {
+			r.emitRawToolChunks()
+			r.buffering = false
+			r.pending = append(r.pending, r.deferred...)
+			r.deferred = nil
+			r.preserveChunkUsage(chunk)
+			// This line may carry usage plus finish_reason. Emit it after the
+			// synthesized tool_calls/finish chunk; it is still ordered after
+			// all earlier deferred events.
+			if text == "" {
+				r.pending = append(r.pending, []byte(line))
+			}
+			return
+		}
+		if text == "" {
+			r.deferred = append(r.deferred, []byte(line))
+		}
+		return
+	}
+	text := collectRawDeltaText(delta)
+	if text == "" {
+		r.pending = append(r.pending, []byte(line))
+		return
+	}
+	if hasCompleteRawToolBlock(text) {
+		r.text.WriteString(text)
+		r.emitRawToolChunks()
+		r.preserveChunkUsage(chunk)
+		if finishReason != "" {
+			r.pending = append(r.pending, []byte(line))
+		}
+		return
+	}
+	if hasRawToolFragment(text) {
+		r.buffering = true
+		r.text.WriteString(text)
+		if finishReason != "" {
+			r.flushIncompleteBuffer()
+			r.pending = append(r.pending, []byte(line))
+		}
+		return
+	}
+	r.pending = append(r.pending, []byte(line))
+}
+
+func collectRawDeltaText(delta map[string]any) string {
+	var b strings.Builder
+	for _, field := range []string{"reasoning", "reasoning_content", "content"} {
+		if s, ok := delta[field].(string); ok && s != "" {
+			b.WriteString(s)
+		}
+	}
+	return b.String()
+}
+
+func (r *rawSSEReader) emitRawToolChunks() {
+	text := r.text.String()
+	r.text.Reset()
+	start := findRawToolStart(text)
+	prefix := strings.TrimSpace(text[:start])
+	toolCalls := parseRawToolCalls(text)
+	if len(toolCalls) == 0 {
+		// The block is complete but unparsable. Preserve only the prefix
+		// rather than leaking the raw markup to the client.
+		if prefix != "" {
+			r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{"content": prefix, "tool_calls": []any{}},
+				}},
+			})))
+		}
+		return
+	}
+	r.converted = true
+	if prefix != "" {
+		r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+			"choices": []any{map[string]any{
+				"index": 0,
+				"delta": map[string]any{"content": prefix, "tool_calls": []any{}},
+			}},
+		})))
+	}
+	for i, tc := range toolCalls {
+		idx := i
+		r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+			"choices": []any{map[string]any{
+				"index": 0,
+				"delta": map[string]any{
+					"role": "assistant",
+					"tool_calls": []any{map[string]any{
+						"index":    idx,
+						"id":       tc.ID,
+						"type":     "function",
+						"function": map[string]any{"name": tc.Function.Name, "arguments": ""},
+					}},
+				},
+			}},
+		})))
+		args := tc.Function.Arguments
+		for len(args) > 0 {
+			size := 32
+			if len(args) < size {
+				size = len(args)
+			}
+			r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{
+						"tool_calls": []any{map[string]any{
+							"index":    idx,
+							"function": map[string]any{"arguments": args[:size]},
+						}},
+					},
+				}},
+			})))
+			args = args[size:]
+		}
+	}
+	r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+		"choices": []any{map[string]any{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "tool_calls",
+		}},
+	})))
+}
+
+func (r *rawSSEReader) preserveChunkUsage(chunk map[string]any) {
+	if u, ok := chunk["usage"]; ok && u != nil {
+		r.pending = append(r.pending, []byte(r.makeUsageOnlyLine(chunk)))
+	}
+}
+
+func (r *rawSSEReader) makeUsageOnlyLine(chunk map[string]any) string {
+	return r.makeDataChunk(map[string]any{
+		"choices": []any{},
+		"usage":   chunk["usage"],
+	})
+}
+
+func (r *rawSSEReader) flushIncompleteBuffer() {
+	if !r.buffering {
+		return
+	}
+	text := r.text.String()
+	r.text.Reset()
+	r.buffering = false
+	if text == "" || hasCompleteRawToolBlock(text) {
+		return
+	}
+	start := findRawToolStart(text)
+	if start > 0 {
+		prefix := strings.TrimSpace(text[:start])
+		if prefix != "" {
+			r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{"content": prefix, "tool_calls": []any{}},
+				}},
+			})))
+		}
+	}
+}
+
+func (r *rawSSEReader) makeDataChunk(body map[string]any) string {
+	base := map[string]any{}
+	if r.chunkID != "" {
+		base["id"] = r.chunkID
+	} else {
+		base["id"] = normalizeChatResponseID("raw-tool-call")
+	}
+	base["object"] = "chat.completion.chunk"
+	if r.model != "" {
+		base["model"] = r.model
+	}
+	if r.created != nil {
+		base["created"] = r.created
+	}
+	for k, v := range body {
+		base[k] = v
+	}
+	b, _ := json.Marshal(base)
+	return "data: " + string(b) + "\n\n"
+}
+
+func (r *rawSSEReader) finishAtEOF() {
+	if r.buffering && r.text.Len() > 0 {
+		text := r.text.String()
+		if hasRawToolFragment(text) && !hasCompleteRawToolBlock(text) {
+			// Never leak a partial raw marker. If there is a recognizable
+			// prefix before it, flush only that prefix.
+			start := findRawToolStart(text)
+			if start > 0 {
+				prefix := strings.TrimSpace(text[:start])
+				if prefix != "" {
+					r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+						"choices": []any{map[string]any{
+							"index": 0,
+							"delta": map[string]any{"content": prefix, "tool_calls": []any{}},
+						}},
+					})))
+				}
+			}
+		} else if text != "" {
+			r.pending = append(r.pending, []byte(r.makeDataChunk(map[string]any{
+				"choices": []any{map[string]any{
+					"index": 0,
+					"delta": map[string]any{"content": text, "tool_calls": []any{}},
+				}},
+			})))
+		}
+		r.buffering = false
+		r.text.Reset()
+	}
+	if len(r.deferred) > 0 {
+		r.pending = append(r.pending, r.deferred...)
+		r.deferred = nil
+	}
+}
+
+// hasRawToolFragment reports whether text contains a known raw marker or the
+// end of text could be the prefix of one. It is intentionally conservative so
+// ordinary prose is never delayed.
+func hasRawToolFragment(text string) bool {
+	normalized := normalizeRawToolCalls(text)
+	if firstMarkerIndex(normalized, rawToolFragmentMarkers) >= 0 {
+		return true
+	}
+	tail := text
+	if len(tail) > 150 {
+		tail = tail[len(tail)-150:]
+	}
+	for _, marker := range rawToolFragmentMarkers {
+		max := len(marker) - 1
+		if max > len(tail) {
+			max = len(tail)
+		}
+		for size := 2; size <= max; size++ {
+			if strings.HasSuffix(tail, marker[:size]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sha256Sum(data []byte) [32]byte {
+	// crypto/sha256 is used by the standard library's SHA-256 constructor;
+	// this indirection keeps call sites in this file compact.
+	return sha256.Sum256(data)
+}

--- a/internal/app/raw_tool_calls_test.go
+++ b/internal/app/raw_tool_calls_test.go
@@ -1,0 +1,703 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeRawToolMarkers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "pipe form",
+			in:   `<|DSML|tool_calls><name>ls</name><parameters>{"path":"."}</parameters></|DSML|tool_calls>`,
+			want: `<｜DSML｜tool_calls><name>ls</name><parameters>{"path":"."}</parameters></｜DSML｜tool_calls>`,
+		},
+		{
+			name: "colon form",
+			in:   `<DSML>tool_calls><DSML:invoke name="ls"><DSML:parameter name="path">.</DSML:parameter></DSML:invoke></DSML>tool_calls>`,
+			want: `<｜DSML｜tool_calls><｜DSML｜invoke name="ls"><｜DSML｜parameter name="path">.</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>`,
+		},
+		{
+			name: "bare tool_calls",
+			in:   `<tool_calls><name>ls</name><parameters>{}</parameters></tool_calls>`,
+			want: `<｜DSML｜tool_calls><name>ls</name><parameters>{}</parameters></｜DSML｜tool_calls>`,
+		},
+		{
+			name: "qwen unchanged",
+			in:   `<tool_call><name>ls</name><parameters>{}</parameters></tool_call>`,
+			want: `<tool_call><name>ls</name><parameters>{}</parameters></tool_call>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeRawToolCalls(tt.in); got != tt.want {
+				t.Fatalf("normalizeRawToolCalls() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasCompleteRawToolBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "fullwidth", in: `<｜DSML｜tool_calls><name>ls</name></｜DSML｜tool_calls>`, want: true},
+		{name: "pipe", in: `<|DSML|tool_calls><name>ls</name></|DSML|tool_calls>`, want: true},
+		{name: "colon", in: `<DSML>tool_calls><name>ls</name></DSML:tool_calls>`, want: true},
+		{name: "colon alt close", in: `<DSML>tool_calls><name>ls</name></DSML>tool_calls>`, want: true},
+		{name: "bare calls", in: `<tool_calls><name>ls</name></tool_calls>`, want: true},
+		{name: "qwen", in: `<tool_call><name>ls</name></tool_call>`, want: true},
+		{name: "qwen function", in: `<function=ls><parameter=path>.</parameter></function>`, want: true},
+		{name: "open only", in: `hello <｜DSML｜tool_calls>`, want: false},
+		{name: "close only", in: `hello </｜DSML｜tool_calls>`, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCompleteRawToolBlock(tt.in); got != tt.want {
+				t.Fatalf("hasCompleteRawToolBlock(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindRawToolStart(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "prefix", in: `ok<｜DSML｜tool_calls><name>ls</name></｜DSML｜tool_calls>`, want: 2},
+		{name: "at start", in: `<tool_call><name>ls</name></tool_call>`, want: 0},
+		{name: "pipe", in: `before <|DSML|tool_calls>`, want: 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findRawToolStart(tt.in); got != tt.want {
+				t.Fatalf("findRawToolStart(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRawToolCalls(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		want  int
+		first string
+		args  string
+	}{
+		{
+			name: "dsml name parameters",
+			in:   `<｜DSML｜tool_calls><name>ls</name><parameters>{"path":"."}</parameters></｜DSML｜tool_calls>`,
+			want: 1, first: "ls", args: `{"path":"."}`,
+		},
+		{
+			name: "dsml invoke",
+			in:   `<｜DSML｜tool_calls><｜DSML｜invoke name="read_file"><｜DSML｜parameter name="path">/tmp/a.txt</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>`,
+			want: 1, first: "read_file", args: `{"path":"/tmp/a.txt"}`,
+		},
+		{
+			name: "qwen",
+			in:   `<tool_call><name>search</name><parameters>{"q":"go"}</parameters></tool_call>`,
+			want: 1, first: "search", args: `{"q":"go"}`,
+		},
+		{
+			name: "qwen function",
+			in:   `<function=search><parameter=q>go</parameter></function>`,
+			want: 1, first: "search", args: `{"q":"go"}`,
+		},
+		{
+			name: "multiple",
+			in:   `<｜DSML｜tool_calls><name>a</name><parameters>{}</parameters><name>b</name><parameters>{"x":1}</parameters></｜DSML｜tool_calls>`,
+			want: 2, first: "a", args: `{}`,
+		},
+		{
+			name: "malformed",
+			in:   `<｜DSML｜tool_calls><name>ls</name></｜DSML｜tool_calls>`,
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRawToolCalls(tt.in)
+			if len(got) != tt.want {
+				t.Fatalf("parseRawToolCalls(%q) = %d calls, want %d: %#v", tt.in, len(got), tt.want, got)
+			}
+			if tt.want > 0 {
+				if got[0].Function.Name != tt.first || got[0].Function.Arguments != tt.args {
+					t.Fatalf("first call = %#v, want name=%q args=%q", got[0], tt.first, tt.args)
+				}
+				if !strings.HasPrefix(got[0].ID, "call_") {
+					t.Fatalf("call ID = %q, want call_ prefix", got[0].ID)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertRawToolCallsInBody(t *testing.T) {
+	rawContent := "prefix" + dsmlOpen + "<name>ls</name><parameters>{\"path\":\".\"}</parameters>" + dsmlClose
+	body, err := json.Marshal(map[string]any{
+		"id": "chatcmpl_test", "model": "m", "created": 1,
+		"choices": []any{map[string]any{
+			"index": 0,
+			"message": map[string]any{
+				"role": "assistant", "content": rawContent, "reasoning_content": "think",
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := convertRawToolCallsInBody(body)
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal converted: %v", err)
+	}
+	choice := got["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "tool_calls" {
+		t.Fatalf("finish_reason = %#v, want tool_calls", choice["finish_reason"])
+	}
+	msg := choice["message"].(map[string]any)
+	if msg["content"] != "prefix" {
+		t.Fatalf("content = %#v, want prefix", msg["content"])
+	}
+	if msg["reasoning_content"] != "think" {
+		t.Fatalf("reasoning_content = %#v, want think", msg["reasoning_content"])
+	}
+	calls := msg["tool_calls"].([]any)
+	if len(calls) != 1 {
+		t.Fatalf("tool_calls = %#v", calls)
+	}
+	fn := calls[0].(map[string]any)["function"].(map[string]any)
+	if fn["name"] != "ls" || fn["arguments"] != `{"path":"."}` {
+		t.Fatalf("function = %#v", fn)
+	}
+	if got["usage"] == nil {
+		t.Fatal("usage must be preserved")
+	}
+}
+
+func TestConvertRawToolCallsInBodySkipsNative(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"<|DSML|tool_calls><name>ls</name></|DSML|tool_calls>","tool_calls":[{"id":"call_native","type":"function","function":{"name":"native","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`)
+	if out := convertRawToolCallsInBody(body); string(out) != string(body) {
+		t.Fatalf("native tool_calls should be preserved unchanged: %s", string(out))
+	}
+}
+
+func TestConvertRawToolCallsInBodyMalformedKeepsOriginal(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"<|DSML|tool_calls><name>ls</name></|DSML|tool_calls>"},"finish_reason":"stop"}]}`)
+	if out := convertRawToolCallsInBody(body); string(out) != string(body) {
+		t.Fatalf("malformed raw block should be left unchanged: %s", string(out))
+	}
+}
+
+func readSSELines(t *testing.T, rc io.ReadCloser) []string {
+	t.Helper()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read wrapped stream: %v", err)
+	}
+	return strings.Split(string(data), "\n\n")
+}
+
+func TestWrapRawSSEConvertsSplitDSML(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"chatcmpl_1","model":"m","choices":[{"delta":{"role":"assistant","content":"<|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"<|DSML|invoke name=\"ls\"><|DSML|parameter name=\"path\">."},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"</|DSML|parameter></|DSML|invoke></|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rc := wrapRawSSE(io.NopCloser(strings.NewReader(upstream)))
+	defer rc.Close()
+	lines := readSSELines(t, rc)
+	if len(lines) == 0 {
+		t.Fatal("no lines")
+	}
+	var foundStart, foundArgs, foundFinish, foundUsage, foundDone bool
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == "data: [DONE]" {
+			foundDone = true
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "data: ") {
+			t.Fatalf("unexpected line %q", line)
+		}
+		var chunk map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(trimmed, "data: ")), &chunk); err != nil {
+			t.Fatalf("bad JSON %q: %v", line, err)
+		}
+		if _, ok := chunk["usage"]; ok {
+			foundUsage = true
+		}
+		choices, _ := chunk["choices"].([]any)
+		if len(choices) == 0 {
+			continue
+		}
+		choice := choices[0].(map[string]any)
+		if fr, _ := choice["finish_reason"].(string); fr == "tool_calls" {
+			foundFinish = true
+		}
+		delta, _ := choice["delta"].(map[string]any)
+		tcs, _ := delta["tool_calls"].([]any)
+		if len(tcs) == 0 {
+			continue
+		}
+		tc := tcs[0].(map[string]any)
+		fn, _ := tc["function"].(map[string]any)
+		if name, _ := fn["name"].(string); name == "ls" {
+			foundStart = true
+		}
+		if args, _ := fn["arguments"].(string); args != "" {
+			foundArgs = true
+		}
+	}
+	if !foundStart || !foundArgs || !foundFinish || !foundUsage || !foundDone {
+		t.Fatalf("missing required chunks start=%v args=%v finish=%v usage=%v done=%v\n%s", foundStart, foundArgs, foundFinish, foundUsage, foundDone, strings.Join(lines, "\n"))
+	}
+	if strings.Contains(strings.Join(lines, ""), "<|DSML|") {
+		t.Fatal("raw marker leaked")
+	}
+}
+
+func TestWrapRawSSEIncompleteFragmentDoesNotLeak(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"before <|DSML|tool_calls><name>ls</name>"},"finish_reason":null}]}`,
+		``,
+	}, "\n")
+	rc := wrapRawSSE(io.NopCloser(strings.NewReader(upstream)))
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(body), "<|DSML|") {
+		t.Fatalf("partial raw marker leaked: %s", body)
+	}
+	if !strings.Contains(string(body), "before") {
+		t.Fatalf("prefix should be flushed: %s", body)
+	}
+}
+
+func TestWrapRawSSENativeToolCallsPassThrough(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"role":"assistant","content":"text","tool_calls":[{"index":0,"id":"call_native","type":"function","function":{"name":"native","arguments":"{}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rc := wrapRawSSE(io.NopCloser(strings.NewReader(upstream)))
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), "call_native") {
+		t.Fatalf("native tool call missing: %s", body)
+	}
+}
+
+func TestCallOpenCodeAPIConvertsNonStreamingRawDSML(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body: func() string {
+			content := "<|DSML|tool_calls><name>ls</name><parameters>" + `{"path":"."}` + "</parameters></|DSML|tool_calls>"
+			b, _ := json.Marshal(map[string]any{
+				"id":    "chatcmpl_test",
+				"model": "m",
+				"choices": []any{map[string]any{
+					"message": map[string]any{
+						"role":              "assistant",
+						"content":           content,
+						"reasoning_content": "think",
+					},
+					"finish_reason": "stop",
+				}},
+				"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+			})
+			return string(b)
+		}(),
+	}})
+	body, status, _, err := callOpenCodeAPI(context.Background(), []byte(`{"model":"primary-model","messages":[]}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err != nil {
+		t.Fatalf("callOpenCodeAPI: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	msg := got["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != nil {
+		t.Fatalf("content = %#v, want nil", msg["content"])
+	}
+	if msg["reasoning_content"] != "think" {
+		t.Fatalf("reasoning_content = %#v", msg["reasoning_content"])
+	}
+	if len(msg["tool_calls"].([]any)) != 1 {
+		t.Fatalf("tool_calls = %#v", msg["tool_calls"])
+	}
+	if got["usage"] == nil {
+		t.Fatal("usage missing")
+	}
+	if len(transport.requestedURLs) != 1 {
+		t.Fatalf("requested URLs = %#v", transport.requestedURLs)
+	}
+}
+
+func TestChatHandlerNonStreamingRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"chatcmpl_test","choices":[{"message":{"role":"assistant","content":"<|DSML|tool_calls><name>ls</name><parameters>{}</parameters></|DSML|tool_calls>"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"primary-model","messages":[],"stream":false}`))
+	rec := httptest.NewRecorder()
+	chatCompletionsHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	msg := got["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if _, ok := msg["tool_calls"].([]any); !ok {
+		t.Fatalf("tool_calls missing: %#v", msg)
+	}
+	if strings.Contains(rec.Body.String(), "<|DSML|") {
+		t.Fatal("raw marker leaked")
+	}
+}
+
+func TestClaudeHandlerNonStreamingRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"chatcmpl_test","choices":[{"message":{"role":"assistant","content":"<tool_call><name>ls</name><parameters>{}</parameters></tool_call>"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"primary-model","messages":[]}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	content := got["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "tool_use" {
+		t.Fatalf("content = %#v, want tool_use", content)
+	}
+}
+
+func TestResponsesHandlerNonStreamingRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   `{"id":"chatcmpl_test","created":1,"choices":[{"message":{"role":"assistant","content":"<tool_call><name>ls</name><parameters>{}</parameters></tool_call>"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"primary-model","input":"hi"}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	output := got["output"].([]any)
+	if len(output) != 1 || output[0].(map[string]any)["type"] != "function_call" {
+		t.Fatalf("output = %#v, want function_call", output)
+	}
+}
+
+func TestClaudeStreamHandlerRawDSML(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"role":"assistant","content":"<|DSML|tool_calls><name>ls</name><parameters>{}</parameters></|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	claudeStreamHandler(context.Background(), rr, wrapRawSSE(io.NopCloser(strings.NewReader(upstream))), "m", false)
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "content_block_start") {
+		t.Fatalf("missing content_block_start:\n%s", rr.Body.String())
+	}
+	foundTool := false
+	for _, e := range events {
+		if e.Name == "content_block_start" {
+			if cb, _ := e.Data["content_block"].(map[string]any); cb["type"] == "tool_use" {
+				foundTool = true
+			}
+		}
+	}
+	if !foundTool {
+		t.Fatalf("tool_use not found:\n%s", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "<|DSML|") {
+		t.Fatal("raw marker leaked")
+	}
+}
+
+func TestResponsesStreamHandlerRawDSML(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"r","created":1,"choices":[{"delta":{"role":"assistant","content":"<tool_call><name>ls</name><parameters>{}</parameters></tool_call>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rr := httptest.NewRecorder()
+	resp := &http.Response{StatusCode: 200, Body: wrapRawSSE(io.NopCloser(strings.NewReader(upstream))), Header: make(http.Header)}
+	responsesStreamHandler(rr, nil, resp, "m", "m", false, nil, nil, ResponsesAPIRequest{})
+	events := parseSSEEvents(t, rr.Body.String())
+	if !hasEvent(events, "response.function_call_arguments.done") {
+		t.Fatalf("missing function_call done:\n%s", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "<tool_call>") {
+		t.Fatal("raw marker leaked")
+	}
+}
+
+func TestCallOpenCodeAPIStreamConvertsRawDSML(t *testing.T) {
+	transport := installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body: strings.Join([]string{
+			`data: {"id":"chatcmpl_test","model":"m","choices":[{"delta":{"role":"assistant","content":"<|DSML|tool_calls>"},"finish_reason":null}]}`,
+			``,
+			`data: {"choices":[{"delta":{"content":"<|DSML|invoke name=\"ls\"><|DSML|parameter name=\"path\">."},"finish_reason":null}]}`,
+			``,
+			`data: {"choices":[{"delta":{"content":"</|DSML|parameter></|DSML|invoke></|DSML|tool_calls>"},"finish_reason":null}]}`,
+			``,
+			`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+			``,
+			`data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+			``,
+			`data: [DONE]`,
+			``,
+		}, "\n"),
+	}})
+	rc, status, _, err := callOpenCodeAPIStream(context.Background(), []byte(`{"model":"primary-model","messages":[],"stream":true}`), "primary-model", UpstreamAuth{Mode: AuthRoutePublic})
+	if err != nil {
+		t.Fatalf("callOpenCodeAPIStream: %v", err)
+	}
+	defer rc.Close()
+	if status != http.StatusOK {
+		t.Fatalf("status = %d", status)
+	}
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(body), "<|DSML|") {
+		t.Fatal("raw marker leaked")
+	}
+	if !strings.Contains(string(body), `"name":"ls"`) || !strings.Contains(string(body), `"finish_reason":"tool_calls"`) {
+		t.Fatalf("converted stream missing tool call/finish: %s", body)
+	}
+	if !strings.Contains(string(body), `"total_tokens":3`) {
+		t.Fatalf("usage missing: %s", body)
+	}
+	if !strings.Contains(string(body), "data: [DONE]") {
+		t.Fatalf("[DONE] missing: %s", body)
+	}
+	if len(transport.requestedURLs) != 1 {
+		t.Fatalf("requested URLs = %#v", transport.requestedURLs)
+	}
+}
+
+func rawStreamBody() string {
+	content := "<|DSML|tool_calls><name>ls</name><parameters>" + `{"path":"."}` + "</parameters></|DSML|tool_calls>"
+	chunks := []any{
+		map[string]any{"id": "chatcmpl_stream", "model": "m", "choices": []any{map[string]any{"delta": map[string]any{"role": "assistant", "content": content}, "finish_reason": nil}}},
+		map[string]any{"choices": []any{map[string]any{"delta": map[string]any{}, "finish_reason": "tool_calls"}}},
+		map[string]any{"choices": []any{}, "usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}},
+	}
+	var lines []string
+	for _, chunk := range chunks {
+		b, err := json.Marshal(chunk)
+		if err != nil {
+			panic(err)
+		}
+		lines = append(lines, "data: "+string(b), "")
+	}
+	lines = append(lines, "data: [DONE]", "")
+	return strings.Join(lines, "\n")
+}
+
+func TestChatStreamHandlerFakeRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   rawStreamBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"primary-model","messages":[],"stream":true}`))
+	rec := httptest.NewRecorder()
+	chatCompletionsHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "<|DSML|") {
+		t.Fatalf("raw marker leaked: %s", body)
+	}
+	if !strings.Contains(body, `"name":"ls"`) || !strings.Contains(body, `"finish_reason":"tool_calls"`) {
+		t.Fatalf("converted stream missing tool_calls/finish: %s", body)
+	}
+	if !strings.Contains(body, `"total_tokens":3`) {
+		t.Fatalf("usage missing: %s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("DONE missing: %s", body)
+	}
+}
+
+func TestClaudeStreamHandlerFakeRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   rawStreamBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"primary-model","messages":[],"stream":true}`))
+	rec := httptest.NewRecorder()
+	claudeMessagesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "<|DSML|") {
+		t.Fatalf("raw marker leaked: %s", body)
+	}
+	events := parseSSEEvents(t, body)
+	foundTool := false
+	for _, e := range events {
+		if e.Name == "content_block_start" {
+			if cb, _ := e.Data["content_block"].(map[string]any); cb["type"] == "tool_use" {
+				foundTool = true
+			}
+		}
+	}
+	if !foundTool {
+		t.Fatalf("tool_use missing: %s", body)
+	}
+}
+
+func TestResponsesStreamHandlerFakeRawDSML(t *testing.T) {
+	installFakeOpenCodeClient(t, []fakeUpstreamResponse{{
+		status: http.StatusOK,
+		body:   rawStreamBody(),
+	}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"primary-model","input":"hi","stream":true}`))
+	rec := httptest.NewRecorder()
+	responsesHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "<|DSML|") {
+		t.Fatalf("raw marker leaked: %s", body)
+	}
+	events := parseSSEEvents(t, body)
+	if !hasEvent(events, "response.function_call_arguments.done") {
+		t.Fatalf("function_call done missing: %s", body)
+	}
+}
+
+func TestWrapRawSSEPreservesUsageOnRawCompletionChunk(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"chatcmpl_u","model":"m","choices":[{"delta":{"role":"assistant","content":"<|DSML|tool_calls><name>ls</name><parameters>{}</parameters></|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rc := wrapRawSSE(io.NopCloser(strings.NewReader(upstream)))
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), `"total_tokens":3`) {
+		t.Fatalf("usage missing from wrapped stream: %s", body)
+	}
+}
+
+func TestWrapRawSSEMaintainsFinishBeforeUsageOrder(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"chatcmpl_order","model":"m","choices":[{"delta":{"role":"assistant","content":"<|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":"<name>ls</name><parameters>{}</parameters></|DSML|tool_calls>"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"choices":[],"usage":{"total_tokens":3}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+	rc := wrapRawSSE(io.NopCloser(strings.NewReader(upstream)))
+	defer rc.Close()
+	lines := readSSELines(t, rc)
+	var sawFinish, sawUsage, sawDone bool
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == "data: [DONE]" {
+			sawDone = true
+			continue
+		}
+		var chunk map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(trimmed, "data: ")), &chunk); err != nil {
+			continue
+		}
+		if _, ok := chunk["usage"]; ok {
+			sawUsage = true
+		}
+		choices, _ := chunk["choices"].([]any)
+		if len(choices) == 0 {
+			continue
+		}
+		if fr, _ := choices[0].(map[string]any)["finish_reason"].(string); fr != "" {
+			if sawUsage {
+				t.Fatalf("finish_reason chunk emitted after usage-only chunk: %s", strings.Join(lines, "\n"))
+			}
+			sawFinish = true
+		}
+	}
+	if !sawFinish || !sawUsage || !sawDone {
+		t.Fatalf("missing finish/usage/done finish=%v usage=%v done=%v", sawFinish, sawUsage, sawDone)
+	}
+}


### PR DESCRIPTION
## Problem

DeepSeek and fine-tuned models can emit raw tool-call markup such as \`<｜DSML｜tool_calls>\`, \`<|DSML|tool_calls>\`, \`<tool_calls>\`, and \`<tool_call>\` inside \`content\` instead of structured \`tool_calls\`. OpenCode and OpenAI-compatible clients hang when they receive this raw markup, because they wait for a structured tool call that never arrives.

This mirrors the behavior of https://github.com/ladiossoop5star/opencode_compat_proxy, but implements the conversion inside opencode2api so all three downstream protocols (Chat, Claude, Responses) are covered by one layer.

## Changes

- \`internal/app/raw_tool_calls.go\`
  - Normalize DSML variants: full-width \`<｜DSML｜tool_calls>\`, pipe \`<|DSML|tool_calls>\`, \`<DSML>tool_calls>\`, bare \`<tool_calls>\`, and Qwen XML \`<tool_call>\`/\`<function=...>\`.
  - Parse DSML \`name/parameters\`, DSML \`invoke/parameter\`, and Qwen \`name/parameters\`/\`function=...\` forms.
  - Non-streaming body converter: only converts when \`message.tool_calls\` is empty and \`content\` has a complete raw block; preserves \`usage\`, \`reasoning_content\`, \`id\`/\`model\`; sets \`finish_reason: tool_calls\`.
  - Streaming SSE \`io.ReadCloser\` wrapper: passes through native \`tool_calls\` and normal content; buffers fragmented raw markers; emits \`role\`/\`name\`/\`arguments\`/\`finish_reason=tool_calls\`; preserves usage-only chunks and \`[DONE]\`; does not leak incomplete raw markers.
- \`internal/app/opencode.go\`
  - \`callOpenCodeAPI\`: convert non-streaming responses after Anthropic normalization and before returning to handlers.
  - \`callOpenCodeAPIStream\`: wrap successful 2xx upstream bodies with \`wrapRawSSE\` so Chat/Claude/Responses streaming handlers all consume normalized Chat SSE.
- \`internal/app/raw_tool_calls_test.go\`: parser tests, non-stream \`callOpenCodeAPI\`/handler tests, stream wrapper tests, and Chat/Claude/Responses streaming endpoint tests using fake upstream raw DSML.
- \`CHANGELOG.md\`: Unreleased entry.

## Verification

- \`go test ./...\` passes.
- \`go vet ./...\` passes.
- Live \`deepseek-v4-flash-free\` requests through \`/v1/chat/completions\` (stream/non-stream), \`/v1/responses\` (stream), and \`/v1/messages\` (stream) returned \`tool_calls\`/\`tool_use\`/\`function_call\` and contained no raw DSML/XML markers. Raw DSML conversion paths are also covered by fake-upstream integration tests.