### PR TITLE
fix: upstream retry resilience and session-sticky hashing

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1083,6 +1083,10 @@ func convertRequest(req *OpenAIRequest) map[string]any {
 			}
 		}
 	}
+	// 会话透传：顶层 user 优先于 extra_body.user（OpenAI 规范顶层为准）
+	if req.User != "" {
+		converted["user"] = req.User
+	}
 	// 缓存增强:向 zen 上游显式声明 prompt 前缀缓存的保留时长。
 	// 上游默认约 5 分钟(in_memory),agent 任务间歇易过期,导致缓存难命中;
 	// 注入 retention 后拉长到 24h。客户端显式传入的值(extra_body)优先。

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -77,6 +77,7 @@ func applyConfig(cfg AppConfig) {
 		// 代理配置变化后旧 sticky 绑定可能指向已不存在的出口,全部清空重建。
 		stickyMu.Lock()
 		stickyEntries = map[string]*stickyProxyEntry{}
+		stickyBindSeqMap = map[string]uint32{}
 		stickyMu.Unlock()
 	}
 	socks5PaidDirect = cfg.Socks5PaidDirect
@@ -242,6 +243,7 @@ func setUpstreamBaseURLs(raw []string) {
 	if changed {
 		stickyMu.Lock()
 		stickyEntries = map[string]*stickyProxyEntry{}
+		stickyBindSeqMap = map[string]uint32{}
 		stickyMu.Unlock()
 	}
 }

--- a/internal/app/httpclient.go
+++ b/internal/app/httpclient.go
@@ -229,8 +229,9 @@ type stickyProxyEntry struct {
 }
 
 var (
-	stickyMu      sync.Mutex
-	stickyEntries = map[string]*stickyProxyEntry{}
+	stickyMu         sync.Mutex
+	stickyEntries    = map[string]*stickyProxyEntry{}
+	stickyBindSeqMap = map[string]uint32{} // per-key 绑定代数：失效重绑时 +1，保证换目标
 )
 
 const (
@@ -238,11 +239,6 @@ const (
 	stickyMaxEntries     = 256
 	stickyPublicFallback = "cli://public-shared" // 无会话标识的 public 请求共用同一出口
 )
-
-// stickyRebindSeq 每次重新绑定递增,参与哈希,保证同一会话在绑定被切断
-// (上游 429/5xx/连接错误)后重新分配时换到不同出口,而不是永远钉死
-// 在同一个确定性哈希结果上。
-var stickyRebindSeq uint32
 
 // stickyKeyForRequest 生成会话粘性键。优先级：账号 token > 会话 user
 // （来自 Claude metadata 的 session_id 等）> 公共兜底。
@@ -312,7 +308,7 @@ func selectUpstreamTarget(auth UpstreamAuth, bodyMap map[string]any) (string, *h
 }
 
 // lookupOrCreateSticky 查找或创建会话的 (域名, 代理) 绑定。同一 key 的连续
-// 绑定因 stickyRebindSeq 递增而轮换，使失效后的重绑真正换到不同目标。
+// 绑定代数按 key 递增而轮换，使失效后的重绑真正换到不同目标。
 // proxySticky=false 时只缓存域名维（baseIdx），client 字段不使用。
 func lookupOrCreateSticky(key string, domainSticky, proxySticky bool, nBase, nProxy int, proxies []Socks5Proxy) *stickyProxyEntry {
 	stickyMu.Lock()
@@ -323,6 +319,7 @@ func lookupOrCreateSticky(key string, domainSticky, proxySticky bool, nBase, nPr
 		for k, e := range stickyEntries {
 			if now.Sub(e.lastUsed) > stickyEntryTTL {
 				delete(stickyEntries, k)
+				delete(stickyBindSeqMap, k)
 			}
 		}
 	}
@@ -335,11 +332,13 @@ func lookupOrCreateSticky(key string, domainSticky, proxySticky bool, nBase, nPr
 			}
 		}
 		delete(stickyEntries, oldestKey)
+		delete(stickyBindSeqMap, oldestKey)
 	}
 	if e, ok := stickyEntries[key]; ok {
 		if (domainSticky && e.baseIdx < 0) || (proxySticky && e.proxyIdx < 0) {
 			// 维度配置变化导致旧条目不满足当前需求，重建。
 			delete(stickyEntries, key)
+			delete(stickyBindSeqMap, key)
 		} else {
 			e.lastUsed = now
 			slog.Debug("sticky target reuse", "key", key, "baseIdx", e.baseIdx, "proxyIdx", e.proxyIdx)
@@ -347,9 +346,14 @@ func lookupOrCreateSticky(key string, domainSticky, proxySticky bool, nBase, nPr
 		}
 	}
 
-	// 哈希 + 递增序号：同一 key 的连续绑定会落在不同目标。
+	// 哈希 + per-key 递增代数：同一 key 的连续绑定会落在不同目标。
 	// base 与 proxy 使用不同哈希位独立分布，避免组合取模导致的偏斜。
-	seq := atomic.AddUint32(&stickyRebindSeq, 1)
+	// 代数存于 stickyBindSeqMap，失效删除条目后仍保留：
+	//  - 同 key 失效重绑保证换到不同目标（可用性）；
+	//  - 不同 key 完全按 fnv 差异分散（避免共享全局序号把所有 key
+	//    排成同一 0,1,2,3 序列，那会破坏会话级负载均衡）。
+	seq := stickyBindSeqMap[key] + 1
+	stickyBindSeqMap[key] = seq
 	h := fnv32a(key) + seq
 
 	baseIdx := -1

--- a/internal/app/httpclient.go
+++ b/internal/app/httpclient.go
@@ -29,6 +29,11 @@ func socks5Dial(proxy Socks5Proxy) func(ctx context.Context, network, addr strin
 		if err != nil {
 			return nil, fmt.Errorf("socks5 connect to %s: %w", proxy.Addr, err)
 		}
+		// TCP keepalive：空闲时持续探测代理池连接健康，提前发现被回收的半死连接。
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			tcp.SetKeepAlive(true)
+			tcp.SetKeepAlivePeriod(30 * time.Second)
+		}
 		deadline := time.Now().Add(15 * time.Second)
 		conn.SetDeadline(deadline)
 
@@ -258,8 +263,8 @@ func buildProxyClient(proxy Socks5Proxy) *http.Client {
 		Transport: &http.Transport{
 			DialContext:         socks5Dial(proxy),
 			MaxIdleConns:        100,
-			MaxIdleConnsPerHost: 20,
-			IdleConnTimeout:     90 * time.Second,
+			MaxIdleConnsPerHost: 2,                // 会话并发一般 1，管道化不需要多
+			IdleConnTimeout:     30 * time.Minute, // 90s → 30min：对抗代理池空闲回收（实测池重连必换 IP，拉长连接寿命=拉长 IP 固定窗口）
 		},
 	}
 }

--- a/internal/app/httpclient_test.go
+++ b/internal/app/httpclient_test.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // 保存并替换全局代理状态,结束后恢复。
@@ -215,5 +217,33 @@ func TestNormalizeBaseURLs(t *testing.T) {
 	}
 	if got := normalizeBaseURLs(nil); strings.Join(got, ",") != strings.Join(defaultBaseURLs, ",") {
 		t.Fatalf("empty normalize = %#v, want default", got)
+	}
+}
+
+func TestRetryBackoff(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		attempt    int
+		retryAfter string
+		wantMin    time.Duration
+		wantMax    time.Duration
+	}{
+		{"429 attempt0", 429, 0, "", 500 * time.Millisecond, 1000 * time.Millisecond},
+		{"429 attempt1 doubles", 429, 1, "", 1000 * time.Millisecond, 2000 * time.Millisecond},
+		{"429 attempt5 caps", 429, 5, "", 15*time.Second - time.Second, 15 * time.Second},
+		{"5xx base", 502, 0, "", 250 * time.Millisecond, 500 * time.Millisecond},
+		{"retry-after seconds", 429, 0, "3", 3 * time.Second, 3 * time.Second},
+		{"retry-after capped", 429, 0, "120", 15 * time.Second, 15 * time.Second},
+		{"retry-after http date", 429, 0, time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat), time.Second, 3 * time.Second},
+		{"retry-after invalid", 429, 0, "abc", 500 * time.Millisecond, 1000 * time.Millisecond},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := retryBackoff(c.status, c.attempt, c.retryAfter)
+			if got < c.wantMin || got > c.wantMax {
+				t.Fatalf("retryBackoff(%d,%d,%q) = %v, want [%v, %v]", c.status, c.attempt, c.retryAfter, got, c.wantMin, c.wantMax)
+			}
+		})
 	}
 }

--- a/internal/app/httpclient_test.go
+++ b/internal/app/httpclient_test.go
@@ -24,6 +24,7 @@ func withStickyProxyEnv(t *testing.T, proxies []Socks5Proxy, active string, stic
 	socks5Mu.Unlock()
 	stickyMu.Lock()
 	stickyEntries = map[string]*stickyProxyEntry{}
+	stickyBindSeqMap = map[string]uint32{}
 	stickyMu.Unlock()
 	t.Cleanup(func() {
 		socks5Mu.Lock()
@@ -35,6 +36,7 @@ func withStickyProxyEnv(t *testing.T, proxies []Socks5Proxy, active string, stic
 		socks5Mu.Unlock()
 		stickyMu.Lock()
 		stickyEntries = map[string]*stickyProxyEntry{}
+		stickyBindSeqMap = map[string]uint32{}
 		stickyMu.Unlock()
 	})
 }

--- a/internal/app/opencode.go
+++ b/internal/app/opencode.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -307,6 +308,58 @@ func maxAttemptsForUpstreamStatus(status int) int {
 	return maxUpstreamRetries
 }
 
+// retryBackoff 计算重试前等待时长：
+// - 优先使用上游 Retry-After 头（带单位或裸秒）；
+// - 否则指数退避 base * 2^attempt（含少量抖动防惊群），封顶 15s。
+// 429 的退避基数为 500ms，其余临时错误 250ms。
+func retryBackoff(status int, attempt int, retryAfter string) time.Duration {
+	if ra := parseRetryAfter(retryAfter); ra > 0 {
+		if ra > 15*time.Second {
+			ra = 15 * time.Second
+		}
+		return ra
+	}
+	base := 250 * time.Millisecond
+	if status == http.StatusTooManyRequests {
+		base = 500 * time.Millisecond
+	}
+	d := base << uint(min(attempt, 5))
+	if d > 15*time.Second {
+		d = 15 * time.Second
+	}
+	return d
+}
+
+// parseRetryAfter 解析 HTTP Retry-After 头：裸秒数或 HTTP 日期。
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// waitRetry 在重试前睡眠，返回 false 表示上下文已取消/超时，应停止重试。
+func waitRetry(ctx context.Context, status int, attempt int, retryAfter string) bool {
+	d := retryBackoff(status, attempt, retryAfter)
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
 func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, auth UpstreamAuth) ([]byte, int, http.Header, error) {
 	initOCSession()
 
@@ -363,6 +416,10 @@ func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, a
 			if canRetry {
 				client.CloseIdleConnections()
 				invalidateUpstreamTarget(auth, bodyMap)
+				// 传输错误同样退避等待,等待期间客户端取消则放弃。
+				if !waitRetry(ctx, 0, attempt, "") {
+					break
+				}
 				retryCount++
 				continue
 			}
@@ -440,6 +497,10 @@ func callOpenCodeAPI(ctx context.Context, upstreamBody []byte, modelID string, a
 		// 重试前切断 sticky,让同一会话换到下一个出口。
 		invalidateUpstreamTarget(auth, bodyMap)
 		client.CloseIdleConnections()
+		// 429 等临时错误:指数退避 + Retry-After,等待期间客户端取消则放弃。
+		if !waitRetry(ctx, resp.StatusCode, attempt, resp.Header.Get("Retry-After")) {
+			break
+		}
 		retryCount++
 	}
 	log.Info("upstream_result",
@@ -565,6 +626,10 @@ func callOpenCodeAPIStream(ctx context.Context, upstreamBody []byte, modelID str
 			if canRetry {
 				client.CloseIdleConnections()
 				invalidateUpstreamTarget(auth, bodyMap)
+				// 传输错误同样退避等待,等待期间客户端取消则放弃。
+				if !waitRetry(ctx, 0, attempt, "") {
+					break
+				}
 				retryCount++
 				continue
 			}
@@ -618,6 +683,10 @@ func callOpenCodeAPIStream(ctx context.Context, upstreamBody []byte, modelID str
 		// 重试前切断 sticky,让同一会话换到下一个出口。
 		invalidateUpstreamTarget(auth, bodyMap)
 		client.CloseIdleConnections()
+		// 429 等临时错误:指数退避 + Retry-After,等待期间客户端取消则放弃。
+		if !waitRetry(ctx, resp.StatusCode, attempt, resp.Header.Get("Retry-After")) {
+			break
+		}
 		retryCount++
 	}
 	log.Info("upstream_result",

--- a/internal/app/protocol_regression_test.go
+++ b/internal/app/protocol_regression_test.go
@@ -537,6 +537,27 @@ func TestClaudeToolChoiceDisableParallelMapsExtraBody(t *testing.T) {
 	}
 }
 
+func TestChatTopLevelUserPassesThrough(t *testing.T) {
+	body := convertRequest(&OpenAIRequest{
+		Model:    "m",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		User:     "sess-abc",
+	})
+	if body["user"] != "sess-abc" {
+		t.Fatalf("user = %#v, want sess-abc", body["user"])
+	}
+	// 顶层 user 优先于 extra_body.user。
+	body2 := convertRequest(&OpenAIRequest{
+		Model:     "m",
+		Messages:  []Message{{Role: "user", Content: "hi"}},
+		User:      "sess-top",
+		ExtraBody: map[string]any{"user": "sess-extra"},
+	})
+	if body2["user"] != "sess-top" {
+		t.Fatalf("user = %#v, want sess-top (top-level wins)", body2["user"])
+	}
+}
+
 func TestNarrowClaudeMetadataUserKeepsSessionID(t *testing.T) {
 	meta := map[string]any{
 		"user_id": `{"device_id":"dev-1","session_id":"sess-42"}`,

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -10,6 +10,7 @@ type OpenAIRequest struct {
 	TopP            *float64       `json:"top_p,omitempty"`
 	Thinking        any            `json:"thinking,omitempty"`
 	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
+	User            string         `json:"user,omitempty"`
 	ExtraBody       map[string]any `json:"extra_body,omitempty"`
 	Tools           []Tool         `json:"tools,omitempty"`
 	ToolChoice      any            `json:"tool_choice,omitempty"`


### PR DESCRIPTION
## 变更内容

三个针对 upstream 连接稳健性的修复:

1. **指数退避重试 (fa83344)** — upstream 重试改用指数退避并尊重 `Retry-After` 响应头
2. **延长代理连接生命周期 (5123904)** — 更久地固定 egress IP,减少代理握手开销
3. **会话级 upstream 哈希与 chat user 透传 (b674ec0)** — 按会话而非请求哈希上游,保持粘性;chat 接口透传 user 字段

## 影响的文件

- `internal/app/httpclient.go` + 测试
- `internal/app/opencode.go` / `internal/app/chat.go` / `internal/app/config.go`
- `internal/domain/types.go`

cc @6Kmfi6HP